### PR TITLE
Update environment file template name in quickstart

### DIFF
--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -23,7 +23,7 @@ icon: "play"
     cd pipeshub-ai/deployment/docker-compose
 
     # Copy and update the environment file
-    cp .env.template .env
+    cp env.template .env
 
     # 👉 Edit the .env file to set secrets, passwords, and the public URLs
     # of the Frontend and Connector services (required for webhook notifications and real-time updates)


### PR DESCRIPTION
The file name in the repo is env.template, not .env.template