### PR TITLE
docs: add Kubernetes (Helm) deployment guide

### DIFF
--- a/deployment/kubernetes/configuration.mdx
+++ b/deployment/kubernetes/configuration.mdx
@@ -1,0 +1,114 @@
+---
+title: "Helm values and configuration"
+description: "How to configure PipesHub’s Helm chart: secrets, storage, URLs, resources, and optional components"
+---
+
+## Recommended baseline `values.yaml`
+
+Create your own `my-values.yaml` and keep secrets out of git.
+
+At minimum, set **`secretKey`**:
+
+```yaml
+secretKey: "REPLACE_ME_WITH_A_LONG_RANDOM_VALUE"
+```
+
+<Note>
+If `secretKey` is left empty, the chart will generate a random value during install. This is fine for quick tests, but for production it can break sessions/encryption across upgrades if the value changes.
+</Note>
+
+## Storage and persistence
+
+The chart creates multiple PVCs (app data plus stateful services). If your cluster does not have a default StorageClass, set one explicitly:
+
+```yaml
+persistence:
+  enabled: true
+  storageClass: "gp3" # example
+
+mongodb:
+  persistence:
+    storageClass: "gp3"
+
+redis:
+  persistence:
+    storageClass: "gp3"
+
+arango:
+  persistence:
+    storageClass: "gp3"
+
+etcd:
+  persistence:
+    storageClass: "gp3"
+
+qdrant:
+  persistence:
+    storageClass: "gp3"
+```
+
+## Public URLs (important when using Ingress)
+
+If you expose PipesHub via hostnames, set:
+
+```yaml
+config:
+  frontendPublicUrl: "https://pipeshub.example.com"
+  connectorPublicBackend: "https://pipeshub-connector.example.com"
+  allowedOrigins: "https://pipeshub.example.com"
+```
+
+## Ingress
+
+Ingress is disabled by default. Enable it and set `className`, `annotations`, `hosts`, and `tls` as needed.
+
+See [`deployment/kubernetes/ingress.mdx`](./ingress.mdx) for complete examples.
+
+## Resources (CPU / memory)
+
+The PipesHub app container defaults to:
+
+- requests \(4 CPU / 4Gi\)
+- limits \(8 CPU / 8Gi\)
+
+For smaller clusters, lower the requests:
+
+```bash
+helm upgrade pipeshub ./deployment/helm/pipeshub-ai -n pipeshub \
+  --set resources.requests.cpu=500m \
+  --set resources.requests.memory=1Gi
+```
+
+## Images and private registries
+
+```yaml
+image:
+  repository: pipeshubai/pipeshub-ai
+  tag: latest
+  pullPolicy: Always
+
+imagePullSecrets:
+  - name: my-registry-cred
+```
+
+## Optional: Neo4j graph database
+
+Neo4j is disabled by default:
+
+```yaml
+neo4j:
+  enabled: false
+  auth:
+    password: "REPLACE_ME"
+```
+
+When enabled, the chart injects Neo4j settings into the PipesHub pod and also stores credentials in the chart-managed Secret.
+
+## Known startup issue: log path permissions
+
+If startup fails due to permissions on `/app/process_monitor.log`, rebuild the image with:
+
+- `LOG_FILE=/data/pipeshub/process_monitor.log`
+
+This aligns with the chart’s default persistent volume mount at `/data/pipeshub`.
+

--- a/deployment/kubernetes/configuration.mdx
+++ b/deployment/kubernetes/configuration.mdx
@@ -62,7 +62,7 @@ config:
 
 Ingress is disabled by default. Enable it and set `className`, `annotations`, `hosts`, and `tls` as needed.
 
-See [`deployment/kubernetes/ingress.mdx`](./ingress.mdx) for complete examples.
+See [`deployment/kubernetes/ingress`](./ingress) for complete examples.
 
 ## Resources (CPU / memory)
 
@@ -74,7 +74,7 @@ The PipesHub app container defaults to:
 For smaller clusters, lower the requests:
 
 ```bash
-helm upgrade pipeshub ./deployment/helm/pipeshub-ai -n pipeshub \
+helm upgrade pipeshub . -n pipeshub \
   --set resources.requests.cpu=500m \
   --set resources.requests.memory=1Gi
 ```

--- a/deployment/kubernetes/helm.mdx
+++ b/deployment/kubernetes/helm.mdx
@@ -3,12 +3,6 @@ title: "Deploy with Helm"
 description: "Install, verify, access, upgrade, and uninstall PipesHub on Kubernetes using Helm"
 ---
 
-## Add the chart to your repo (recommended)
-
-If you are working from this documentation repo, the chart is available at `deployment/helm/pipeshub-ai` (symlinked from the `pipeshub-ai` repo).
-
-If you vendor the chart into your own repo/CI, keep the same directory layout so the commands below remain correct.
-
 ## Install PipesHub
 
 <Steps>
@@ -20,11 +14,32 @@ kubectl create namespace pipeshub
 
   </Step>
 
+  <Step title="Clone the official repo">
+
+```bash
+git clone https://github.com/pipeshub-ai/pipeshub-ai.git
+cd pipeshub-ai/deployment/helm/pipeshub-ai
+```
+
+  </Step>
+
+  <Step title="Create a minimal values file (recommended)">
+
+Create `my-values.yaml` and set at least `secretKey`:
+
+```bash
+cat > my-values.yaml <<'YAML'
+secretKey: "REPLACE_ME_WITH_A_LONG_RANDOM_VALUE"
+YAML
+```
+
+  </Step>
+
   <Step title="Install the chart">
 
 ```bash
-helm dependency update ./deployment/helm/pipeshub-ai
-helm install pipeshub ./deployment/helm/pipeshub-ai -n pipeshub
+helm dependency update .
+helm install pipeshub . -n pipeshub -f my-values.yaml
 ```
 
   </Step>
@@ -84,12 +99,12 @@ Most deployments should set at least:
 - `persistence.storageClass` (if your cluster doesn’t have a default)
 - `config.frontendPublicUrl` / `config.connectorPublicBackend` (when using Ingress)
 
-See [`deployment/kubernetes/configuration.mdx`](./configuration.mdx) for a complete set of recommended overrides.
+See [`deployment/kubernetes/configuration`](./configuration) for a complete set of recommended overrides.
 
 ## Upgrade PipesHub
 
 ```bash
-helm upgrade pipeshub ./deployment/helm/pipeshub-ai -n pipeshub -f my-values.yaml
+helm upgrade pipeshub . -n pipeshub -f my-values.yaml
 ```
 
 ## Uninstall

--- a/deployment/kubernetes/helm.mdx
+++ b/deployment/kubernetes/helm.mdx
@@ -1,0 +1,104 @@
+---
+title: "Deploy with Helm"
+description: "Install, verify, access, upgrade, and uninstall PipesHub on Kubernetes using Helm"
+---
+
+## Add the chart to your repo (recommended)
+
+If you are working from this documentation repo, the chart is available at `deployment/helm/pipeshub-ai` (symlinked from the `pipeshub-ai` repo).
+
+If you vendor the chart into your own repo/CI, keep the same directory layout so the commands below remain correct.
+
+## Install PipesHub
+
+<Steps>
+  <Step title="Create a namespace (recommended)">
+
+```bash
+kubectl create namespace pipeshub
+```
+
+  </Step>
+
+  <Step title="Install the chart">
+
+```bash
+helm dependency update ./deployment/helm/pipeshub-ai
+helm install pipeshub ./deployment/helm/pipeshub-ai -n pipeshub
+```
+
+  </Step>
+</Steps>
+
+<Note>
+Release names affect resource names. For example, with release name `pipeshub`, the main Service becomes `pipeshub-pipeshub-ai`.
+</Note>
+
+## Verify the installation
+
+```bash
+helm list -n pipeshub
+kubectl get pods -n pipeshub
+kubectl get svc -n pipeshub
+```
+
+Wait until all pods are `Running` and readiness probes are healthy.
+
+## Access PipesHub
+
+By default, the chart creates a ClusterIP Service exposing these ports:
+
+- **3000**: frontend
+- **8088**: connector
+- **8091**: main backend (indexing backend uses the same pod, different port naming)
+- **8000**: query
+- **8081**: indexing
+
+For local testing, port-forward the frontend:
+
+```bash
+kubectl -n pipeshub port-forward service/pipeshub-pipeshub-ai 3000:3000
+```
+
+Then open `http://localhost:3000`.
+
+<Note>
+If you used a different Helm release name, the Service name will be different. You can always discover it with:
+
+```bash
+kubectl -n pipeshub get svc
+```
+</Note>
+
+If you also need the connector endpoint locally:
+
+```bash
+kubectl -n pipeshub port-forward service/pipeshub-pipeshub-ai 8088:8088
+```
+
+## Configure PipesHub
+
+Most deployments should set at least:
+
+- `secretKey`
+- `persistence.storageClass` (if your cluster doesn’t have a default)
+- `config.frontendPublicUrl` / `config.connectorPublicBackend` (when using Ingress)
+
+See [`deployment/kubernetes/configuration.mdx`](./configuration.mdx) for a complete set of recommended overrides.
+
+## Upgrade PipesHub
+
+```bash
+helm upgrade pipeshub ./deployment/helm/pipeshub-ai -n pipeshub -f my-values.yaml
+```
+
+## Uninstall
+
+```bash
+helm uninstall pipeshub -n pipeshub
+```
+
+<Note>
+PersistentVolumeClaims are not always deleted automatically depending on your cluster’s reclaim policies. If you are deleting a test environment, verify and clean up PVCs in the namespace.
+</Note>
+

--- a/deployment/kubernetes/helm.mdx
+++ b/deployment/kubernetes/helm.mdx
@@ -61,35 +61,34 @@ Wait until all pods are `Running` and readiness probes are healthy.
 
 ## Access PipesHub
 
-By default, the chart creates a ClusterIP Service exposing these ports:
+By default, the chart creates a **ClusterIP** Service for the PipesHub app. That Service is only reachable from inside the cluster unless you add Ingress, change the Service type, or use **port-forward** from your machine.
 
-- **3000**: frontend
-- **8088**: connector
-- **8091**: main backend (indexing backend uses the same pod, different port naming)
-- **8000**: query
-- **8081**: indexing
-
-For local testing, port-forward the frontend:
-
-```bash
-kubectl -n pipeshub port-forward service/pipeshub-pipeshub-ai 3000:3000
-```
-
-Then open `http://localhost:3000`.
-
-<Note>
-If you used a different Helm release name, the Service name will be different. You can always discover it with:
+See how the app is exposed:
 
 ```bash
 kubectl -n pipeshub get svc
+kubectl -n pipeshub describe svc <your-release>-pipeshub-ai
 ```
-</Note>
 
-If you also need the connector endpoint locally:
+Replace `<your-release>-pipeshub-ai` with the Service name from `get svc` (for example, release name `pipeshub` often yields `pipeshub-pipeshub-ai`).
+
+To try the **web UI** locally, forward the Service using the port **name** `frontend`:
 
 ```bash
-kubectl -n pipeshub port-forward service/pipeshub-pipeshub-ai 8088:8088
+kubectl -n pipeshub port-forward service/<your-release>-pipeshub-ai :frontend
 ```
+
+`kubectl` prints a local address; open that URL in your browser.
+
+To reach the **connector** locally, run a separate forward using the port **name** `connector`:
+
+```bash
+kubectl -n pipeshub port-forward service/<your-release>-pipeshub-ai :connector
+```
+
+<Note>
+If you used a different Helm release name, the Service name will differ. Always confirm with `kubectl -n pipeshub get svc`.
+</Note>
 
 ## Configure PipesHub
 

--- a/deployment/kubernetes/ingress.mdx
+++ b/deployment/kubernetes/ingress.mdx
@@ -5,9 +5,9 @@ description: "Expose PipesHub with Kubernetes Ingress, including host routing an
 
 ## Enable Ingress
 
-The chart’s Ingress is driven entirely by `ingress.hosts[].paths[]`, where each path specifies a **service name** and **port number**.
+The chart’s Ingress is driven entirely by `ingress.hosts[].paths[]`, where each path specifies a **service name** and a **port** field. That field must match the **numeric** port shown for the correct **named** port on your Service (check `kubectl get svc` / `kubectl describe svc` — e.g. the rows named `frontend` and `connector`).
 
-Start with a `my-values.yaml` like:
+Start with a `my-values.yaml` like (fill `port` from your cluster after `kubectl get svc -n pipeshub`):
 
 ```yaml
 ingress:
@@ -19,13 +19,13 @@ ingress:
       paths:
         - path: /
           pathType: ImplementationSpecific
-          port: 3000
+          port: <frontend-port-from-kubectl-get-svc>
           serviceName: pipeshub-pipeshub-ai
     - host: pipeshub-connector.example.com
       paths:
         - path: /
           pathType: ImplementationSpecific
-          port: 8088
+          port: <connector-port-from-kubectl-get-svc>
           serviceName: pipeshub-pipeshub-ai
   tls:
     - secretName: pipeshub-example-com-tls

--- a/deployment/kubernetes/ingress.mdx
+++ b/deployment/kubernetes/ingress.mdx
@@ -53,7 +53,7 @@ config:
 ## Apply the change
 
 ```bash
-helm upgrade pipeshub ./deployment/helm/pipeshub-ai -n pipeshub -f my-values.yaml
+helm upgrade pipeshub . -n pipeshub -f my-values.yaml
 kubectl get ingress -n pipeshub
 ```
 

--- a/deployment/kubernetes/ingress.mdx
+++ b/deployment/kubernetes/ingress.mdx
@@ -1,0 +1,68 @@
+---
+title: "Ingress and TLS"
+description: "Expose PipesHub with Kubernetes Ingress, including host routing and HTTPS"
+---
+
+## Enable Ingress
+
+The chart’s Ingress is driven entirely by `ingress.hosts[].paths[]`, where each path specifies a **service name** and **port number**.
+
+Start with a `my-values.yaml` like:
+
+```yaml
+ingress:
+  enabled: true
+  className: "nginx"
+  annotations: {}
+  hosts:
+    - host: pipeshub.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          port: 3000
+          serviceName: pipeshub-pipeshub-ai
+    - host: pipeshub-connector.example.com
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+          port: 8088
+          serviceName: pipeshub-pipeshub-ai
+  tls:
+    - secretName: pipeshub-example-com-tls
+      hosts:
+        - pipeshub.example.com
+    - secretName: pipeshub-connector-example-com-tls
+      hosts:
+        - pipeshub-connector.example.com
+```
+
+<Note>
+The `serviceName` must match the actual Kubernetes Service created by the release. With the install command `helm install pipeshub ...`, the default service name is `pipeshub-pipeshub-ai`.
+</Note>
+
+## Set public URLs
+
+When using ingress, set:
+
+```yaml
+config:
+  frontendPublicUrl: "https://pipeshub.example.com"
+  connectorPublicBackend: "https://pipeshub-connector.example.com"
+```
+
+## Apply the change
+
+```bash
+helm upgrade pipeshub ./deployment/helm/pipeshub-ai -n pipeshub -f my-values.yaml
+kubectl get ingress -n pipeshub
+```
+
+## Troubleshooting Ingress
+
+- If Ingress exists but routing fails, verify your ingress controller is installed and watching the namespace.
+- If you get 404s, confirm `hosts` and `paths` match what your controller expects and that the service/port exist:
+
+```bash
+kubectl get svc -n pipeshub
+```
+

--- a/deployment/kubernetes/overview.mdx
+++ b/deployment/kubernetes/overview.mdx
@@ -31,6 +31,19 @@ Most of these services are stateful and require Persistent Volumes. Plan for sto
 - **StorageClass**: A default StorageClass, or provide explicit `storageClass` values for the PVCs.
 - **Ingress controller (optional)**: Only required if you plan to expose PipesHub via Ingress.
 
+Before you install, it helps to confirm your `kubectl` context is pointing at the right cluster:
+
+```bash
+kubectl cluster-info
+kubectl get nodes
+```
+
+And confirm you have a StorageClass available:
+
+```bash
+kubectl get storageclass
+```
+
 ## Sizing baseline
 
 The chart defaults are aimed at a reasonably-sized cluster:
@@ -40,7 +53,11 @@ The chart defaults are aimed at a reasonably-sized cluster:
 For local clusters like `kind` or small nodes, you’ll likely need to lower requests so the pod can schedule:
 
 ```bash
-helm install pipeshub ./deployment/helm/pipeshub-ai -n pipeshub \
+git clone https://github.com/pipeshub-ai/pipeshub-ai.git
+cd pipeshub-ai/deployment/helm/pipeshub-ai
+
+helm dependency update .
+helm install pipeshub . -n pipeshub \
   --set resources.requests.cpu=500m \
   --set resources.requests.memory=1Gi
 ```

--- a/deployment/kubernetes/overview.mdx
+++ b/deployment/kubernetes/overview.mdx
@@ -11,7 +11,7 @@ PipesHub can be deployed on Kubernetes using a single Helm chart. The chart depl
 
 At a high level, the chart deploys:
 
-- **PipesHub app**: One Kubernetes `Deployment` exposing multiple ports (API / frontend / connector / query / indexing).
+- **PipesHub app**: One Kubernetes `Deployment` exposing several in-cluster endpoints (web UI, connector API, query, indexing, and related traffic).
 - **MongoDB**: Primary document store (via Bitnami dependency chart).
 - **Redis**: Cache and session store (via Bitnami dependency chart).
 - **ArangoDB**: Graph + multi-model database for relationships.

--- a/deployment/kubernetes/overview.mdx
+++ b/deployment/kubernetes/overview.mdx
@@ -1,0 +1,53 @@
+---
+title: "Kubernetes Overview"
+description: "What gets deployed and what you need before installing PipesHub on Kubernetes"
+---
+
+## Overview
+
+PipesHub can be deployed on Kubernetes using a single Helm chart. The chart deploys the PipesHub application plus its required data services.
+
+## What gets deployed
+
+At a high level, the chart deploys:
+
+- **PipesHub app**: One Kubernetes `Deployment` exposing multiple ports (API / frontend / connector / query / indexing).
+- **MongoDB**: Primary document store (via Bitnami dependency chart).
+- **Redis**: Cache and session store (via Bitnami dependency chart).
+- **ArangoDB**: Graph + multi-model database for relationships.
+- **Qdrant**: Vector database for embeddings and semantic search.
+- **etcd**: Key-value store used by PipesHub internal services.
+- **Kafka + ZooKeeper**: Eventing / async processing infrastructure.
+- **Neo4j (optional)**: Alternative graph database (disabled by default).
+
+<Note>
+Most of these services are stateful and require Persistent Volumes. Plan for storage early (StorageClass, PVC sizing, backups).
+</Note>
+
+## Prerequisites
+
+- **Kubernetes cluster**: Any conformant cluster where you can create namespaces, services, and PVCs.
+- **Helm**: Helm v3 installed on your machine/CI runner.
+- **StorageClass**: A default StorageClass, or provide explicit `storageClass` values for the PVCs.
+- **Ingress controller (optional)**: Only required if you plan to expose PipesHub via Ingress.
+
+## Sizing baseline
+
+The chart defaults are aimed at a reasonably-sized cluster:
+
+- **PipesHub app container**: requests \(4 CPU / 4Gi\), limits \(8 CPU / 8Gi\)
+
+For local clusters like `kind` or small nodes, you’ll likely need to lower requests so the pod can schedule:
+
+```bash
+helm install pipeshub ./deployment/helm/pipeshub-ai -n pipeshub \
+  --set resources.requests.cpu=500m \
+  --set resources.requests.memory=1Gi
+```
+
+## Next steps
+
+- Follow the Helm install guide in [`deployment/kubernetes/helm`](./helm).
+- Configure values (secrets, persistence, URLs) in [`deployment/kubernetes/configuration`](./configuration).
+- If you want HTTPS + hostnames, see [`deployment/kubernetes/ingress`](./ingress).
+

--- a/deployment/kubernetes/troubleshooting.mdx
+++ b/deployment/kubernetes/troubleshooting.mdx
@@ -19,7 +19,7 @@ Common causes:
 - No default StorageClass in the cluster
 - Wrong `storageClass` name in values
 
-Fix by setting the StorageClass in values (see [`deployment/kubernetes/configuration.mdx`](./configuration.mdx)) and re-running `helm upgrade`.
+Fix by setting the StorageClass in values (see [`deployment/kubernetes/configuration`](./configuration.mdx)) and re-running `helm upgrade`.
 
 ## CrashLoopBackOff on the app pod
 

--- a/deployment/kubernetes/troubleshooting.mdx
+++ b/deployment/kubernetes/troubleshooting.mdx
@@ -36,7 +36,7 @@ Then redeploy with the new `image.tag`.
 The chart’s default requests for the app container are \(4 CPU / 4Gi\). For kind/small clusters, lower them:
 
 ```bash
-helm upgrade pipeshub ./deployment/helm/pipeshub-ai -n pipeshub \
+helm upgrade pipeshub . -n pipeshub \
   --set resources.requests.cpu=500m \
   --set resources.requests.memory=1Gi
 ```

--- a/deployment/kubernetes/troubleshooting.mdx
+++ b/deployment/kubernetes/troubleshooting.mdx
@@ -1,0 +1,75 @@
+---
+title: "Troubleshooting"
+description: "Common issues and fixes when running PipesHub on Kubernetes"
+---
+
+## Pods stuck in Pending
+
+### PVC Pending / unbound
+
+If pods are waiting on volumes, check PVCs:
+
+```bash
+kubectl get pvc -n pipeshub
+kubectl describe pvc -n pipeshub
+```
+
+Common causes:
+
+- No default StorageClass in the cluster
+- Wrong `storageClass` name in values
+
+Fix by setting the StorageClass in values (see [`deployment/kubernetes/configuration.mdx`](./configuration.mdx)) and re-running `helm upgrade`.
+
+## CrashLoopBackOff on the app pod
+
+### Log file permissions (`/app/process_monitor.log`)
+
+If the container fails early due to permissions on `/app/process_monitor.log`, rebuild the image with:
+
+- `LOG_FILE=/data/pipeshub/process_monitor.log`
+
+Then redeploy with the new `image.tag`.
+
+### Pod can’t schedule (resource requests too high)
+
+The chart’s default requests for the app container are \(4 CPU / 4Gi\). For kind/small clusters, lower them:
+
+```bash
+helm upgrade pipeshub ./deployment/helm/pipeshub-ai -n pipeshub \
+  --set resources.requests.cpu=500m \
+  --set resources.requests.memory=1Gi
+```
+
+## ImagePullBackOff
+
+Check events and confirm registry credentials:
+
+```bash
+kubectl describe pod -n pipeshub <pod-name>
+```
+
+If using a private image registry, configure `imagePullSecrets` in your values file.
+
+## Ingress issues
+
+If Ingress is enabled but traffic doesn’t route:
+
+- Verify you have an ingress controller installed.
+- Confirm `serviceName` + `port` in `ingress.hosts[].paths[]` matches the Service created by your Helm release.
+
+## Neo4j Browser can’t connect (WebSocket failure)
+
+If you enabled Neo4j and opened Neo4j Browser on `http://localhost:7474` but get a WebSocket connection failure, you likely forwarded only the HTTP port (7474).
+
+Neo4j Browser also needs access to **Bolt** (7687). Port-forward both:
+
+```bash
+kubectl -n pipeshub port-forward service/<release>-pipeshub-ai-neo4j 7474:7474 7687:7687
+```
+
+Then connect in Neo4j Browser using:
+
+- URL: `neo4j://localhost:7687` (or `bolt://localhost:7687`)
+- Username: `neo4j`
+- Password: the value you configured in `neo4j.auth.password` (or the chart-generated secret)

--- a/deployment/overview.mdx
+++ b/deployment/overview.mdx
@@ -3,9 +3,23 @@ title: "Deployment Overview"
 description: "Overview of the PipesHub Workplace AI Deployment"
 ---
 
-<div className="flex flex-col items-center justify-center text-center pt-10">
-  <h1 className=" font-bold">🚧 Coming Soon</h1>
-  <h3 className="text-xl mt-2">
-    We are working hard to bring you this content. Please check back shortly!
-  </h3>
-</div>
+## Deployment options
+
+PipesHub can be deployed in multiple ways depending on your environment and operational needs.
+
+## Kubernetes (Helm)
+
+- **Start here**: [`deployment/kubernetes/overview.mdx`](./kubernetes/overview.mdx)
+- **Install/upgrade**: [`deployment/kubernetes/helm.mdx`](./kubernetes/helm.mdx)
+- **Configuration**: [`deployment/kubernetes/configuration.mdx`](./kubernetes/configuration.mdx)
+- **Ingress + TLS**: [`deployment/kubernetes/ingress.mdx`](./kubernetes/ingress.mdx)
+- **Troubleshooting**: [`deployment/kubernetes/troubleshooting.mdx`](./kubernetes/troubleshooting.mdx)
+
+## Cloud vendors
+
+If you want a VM-based deployment on a specific provider, see:
+
+- AWS: [`deployment/vendor/aws.mdx`](./vendor/aws.mdx)
+- Azure: [`deployment/vendor/azure.mdx`](./vendor/azure.mdx)
+- GCP: [`deployment/vendor/gcp.mdx`](./vendor/gcp.mdx)
+- Private cloud: [`deployment/vendor/private.mdx`](./vendor/private.mdx)

--- a/docs.json
+++ b/docs.json
@@ -200,6 +200,16 @@
         "pages": [
           "deployment/overview",
           {
+            "group": "Kubernetes",
+            "pages": [
+              "deployment/kubernetes/overview",
+              "deployment/kubernetes/helm",
+              "deployment/kubernetes/configuration",
+              "deployment/kubernetes/ingress",
+              "deployment/kubernetes/troubleshooting"
+            ]
+          },
+          {
             "group": "Vendor",
             "pages": [
               "deployment/vendor/aws",

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -57,3 +57,4 @@ PipesHub Agents are built on top of PipesHub Actions, which connect with enterpr
 
 ## Deployment
 PipesHub Workplace AI platform can be run locally on your machine or deployed on cloud with `docker compose`.
+For production deployments, PipesHub also supports **Kubernetes via Helm**. See the Kubernetes deployment docs under [`deployment/kubernetes/overview`](./deployment/kubernetes/overview).


### PR DESCRIPTION
## Summary

- Added Kubernetes deployment documentation for PipesHub using Helm (install, verify, access, configure, ingress/TLS, troubleshooting).
- Updated docs navigation and deployment landing page so the new Kubernetes section appears on `docs.pipeshub.com`.

## Scope

- New pages:
  - `deployment/kubernetes/overview.mdx`
  - `deployment/kubernetes/helm.mdx`
  - `deployment/kubernetes/configuration.mdx`
  - `deployment/kubernetes/ingress.mdx`
  - `deployment/kubernetes/troubleshooting.mdx`
- Updated:
  - `deployment/overview.mdx`
  - `docs.json`
  - `introduction.mdx` (Deployment section now mentions Kubernetes/Helm)
- Note:
  - `deployment/helm` is a symlink to the Helm chart source for reference during docs development.

## Test / verification

- [ ] Ran `mintlify dev` and verified navigation + links
- [ ] Verified MDX renders (Steps/Note/code blocks)
- [ ] Checked for broken links / missing pages in `docs.json`

## Screenshots
<img width="1893" height="943" alt="image" src="https://github.com/user-attachments/assets/23766e14-5a23-4fa0-b52b-3c31538ac40d" />
