### PR TITLE
Docs: install PipesHub with one curl command

### DIFF
--- a/deployment/vendor/gcp.mdx
+++ b/deployment/vendor/gcp.mdx
@@ -162,7 +162,7 @@ newgrp docker
 Install required network utilities:
 
 ```bash
-sudo apt install -y net-tools nginx
+sudo apt install -y net-tools nginx git
 ```
 
   </Step>
@@ -424,7 +424,7 @@ To pin a specific version instead of the rolling `latest`/`slim` tag, pass `--ve
 PipesHub uses multiple databases and storage systems. Choose one of the following backup strategies:
 
 <Note>
-Run backup and restore commands from the install directory (`~/pipeshub`). Compose names containers `{project}-{service}-1` (default project `pipeshub-ai`), so use `docker compose -p pipeshub-ai exec <service>` rather than `docker exec mongodb`. The `kafka-1` service only exists if you selected Kafka as the message broker during installation; if you're on the default (Redis broker), skip that command.
+Backup and restore copy-paste blocks `cd ~/pipeshub` themselves so Compose finds `docker-compose.yml` and loads `COMPOSE_PROFILES` from `.env`. Compose names containers `{project}-{service}-1` (default project `pipeshub-ai`), so use `docker compose -p pipeshub-ai exec <service>` rather than `docker exec mongodb`. The `kafka-1` service only exists if you selected Kafka as the message broker during installation; if you're on the default (Redis broker), skip that command.
 </Note>
 
 <AccordionGroup>
@@ -434,7 +434,11 @@ Run backup and restore commands from the install directory (`~/pipeshub`). Compo
 Use database-specific backup tools that create consistent snapshots without downtime:
 
 ```bash
-# Create backup directory
+cd ~/pipeshub
+set -a
+. ./.env
+set +a
+
 mkdir -p ~/pipeshub-backups
 BACKUP_DATE=$(date +%Y%m%d-%H%M%S)
 
@@ -450,6 +454,7 @@ sudo docker compose -p pipeshub-ai exec -T mongodb rm -rf /tmp/mongodb-backup
 # Backup Neo4j using neo4j-admin
 # `neo4j-admin database dump` requires an OFFLINE database (Community Edition),
 # so stop the container and dump directly from its volume via a throwaway container.
+# neo4j is profile-gated — COMPOSE_PROFILES must be loaded from ~/pipeshub/.env.
 sudo docker compose -p pipeshub-ai stop neo4j
 mkdir -p ~/pipeshub-backups/neo4j-backup-${BACKUP_DATE}
 sudo docker run --rm \
@@ -468,10 +473,14 @@ QDRANT_SNAPSHOT_NAME=$(echo "$QDRANT_SNAPSHOT_RESPONSE" | grep -oP '"name"\s*:\s
 sudo docker compose -p pipeshub-ai cp "qdrant:/qdrant/snapshots/${QDRANT_SNAPSHOT_NAME}" \
   ~/pipeshub-backups/qdrant-backup-${BACKUP_DATE}.snapshot
 
-# Backup Redis using BGSAVE
+# Backup Redis using BGSAVE (asynchronous — wait until it finishes)
 sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning BGSAVE
-# Wait for BGSAVE to complete
-sleep 5
+while sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning INFO persistence \
+  | grep -q '^rdb_bgsave_in_progress:1'; do
+  sleep 1
+done
+sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning INFO persistence \
+  | grep -q '^rdb_last_bgsave_status:ok' || { echo "Redis BGSAVE failed"; exit 1; }
 sudo docker compose -p pipeshub-ai cp redis:/data/dump.rdb \
   ~/pipeshub-backups/redis-backup-${BACKUP_DATE}.rdb
 
@@ -630,6 +639,12 @@ cd ~/pipeshub && ./install.sh --stop
 cd ~/pipeshub-backups
 tar xzf pipeshub-full-backup-${BACKUP_DATE}.tar.gz
 
+# Compose needs the project directory (and .env / COMPOSE_PROFILES) — not the backup folder
+cd ~/pipeshub
+set -a
+. ./.env
+set +a
+
 # Start only MongoDB and Redis for now — leave Neo4j and Qdrant stopped since both
 # `neo4j-admin database load` and Qdrant's full-storage snapshot recovery require
 # an OFFLINE database
@@ -772,6 +787,11 @@ echo "Restore completed successfully"
 After restoring, verify that all services are running correctly:
 
 ```bash
+cd ~/pipeshub
+set -a
+. ./.env
+set +a
+
 # Check container status
 sudo docker compose -p pipeshub-ai ps
 
@@ -782,7 +802,11 @@ sudo docker compose -p pipeshub-ai logs --tail=50
 sudo docker compose -p pipeshub-ai exec -T mongodb mongosh --eval "db.adminCommand('ping')"
 sudo docker compose -p pipeshub-ai exec -T neo4j wget -qO- http://localhost:7474
 sudo docker compose -p pipeshub-ai exec -T qdrant curl -s http://localhost:6333/health
-sudo docker compose -p pipeshub-ai exec -T redis redis-cli ping
+if [ -n "${REDIS_PASSWORD:-}" ]; then
+  sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning ping
+else
+  sudo docker compose -p pipeshub-ai exec -T redis redis-cli ping
+fi
 
 # Access the application
 echo "Access PipesHub at https://your-domain.com"

--- a/deployment/vendor/gcp.mdx
+++ b/deployment/vendor/gcp.mdx
@@ -169,7 +169,7 @@ sudo apt install -y net-tools nginx git
 
   <Step title="Install PipesHub">
 
-Add your user to the `docker` group (see the Docker step above) and run `newgrp docker` (or log out and back in) **before** this step, so the installer can talk to the daemon without `curl | sudo bash`. Later commands still use `sudo docker` so they work if you skip the group.
+Add your user to the `docker` group (see the Docker step above) and run `newgrp docker` (or log out and back in) **before** this step. `curl | bash` and later `./install.sh --stop` / `--uninstall` talk to Docker without sudo, so they fail if you skip the group. Commands that start with `sudo docker` still work without it.
 
 The recommended install does not clone the repository. It downloads the installer and writes Compose files into `~/pipeshub`:
 
@@ -479,18 +479,26 @@ else
     ~/pipeshub-backups/qdrant-backup-${BACKUP_DATE}.snapshot
 fi
 
-# Backup Redis using BGSAVE (asynchronous — wait until it finishes)
-sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning BGSAVE
-while sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning INFO persistence \
-  | grep -q '^rdb_bgsave_in_progress:1'; do
-  sleep 1
-done
-if sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning INFO persistence \
-  | grep -q '^rdb_last_bgsave_status:ok'; then
-  sudo docker compose -p pipeshub-ai cp redis:/data/dump.rdb \
-    ~/pipeshub-backups/redis-backup-${BACKUP_DATE}.rdb
+# Backup Redis using BGSAVE (asynchronous — wait until it finishes).
+# The installer always writes REDIS_PASSWORD; omit -a only if you cleared it.
+REDIS_AUTH=(--no-auth-warning)
+[ -n "${REDIS_PASSWORD:-}" ] && REDIS_AUTH+=(-a "${REDIS_PASSWORD}")
+REDIS_BGSAVE=$(sudo docker compose -p pipeshub-ai exec -T redis redis-cli "${REDIS_AUTH[@]}" BGSAVE)
+echo "${REDIS_BGSAVE}"
+if echo "${REDIS_BGSAVE}" | grep -qi 'Background saving started'; then
+  while sudo docker compose -p pipeshub-ai exec -T redis redis-cli "${REDIS_AUTH[@]}" INFO persistence \
+    | grep -q '^rdb_bgsave_in_progress:1'; do
+    sleep 1
+  done
+  if sudo docker compose -p pipeshub-ai exec -T redis redis-cli "${REDIS_AUTH[@]}" INFO persistence \
+    | grep -q '^rdb_last_bgsave_status:ok'; then
+    sudo docker compose -p pipeshub-ai cp redis:/data/dump.rdb \
+      ~/pipeshub-backups/redis-backup-${BACKUP_DATE}.rdb
+  else
+    echo "Redis BGSAVE failed — not copying dump.rdb"
+  fi
 else
-  echo "Redis BGSAVE failed — not copying dump.rdb"
+  echo "Redis BGSAVE did not start — not copying dump.rdb"
 fi
 
 # Backup application data (safe to use tar for non-database files)
@@ -696,15 +704,26 @@ sleep 20
 sudo docker rm -f qdrant-restore
 sudo docker compose -p pipeshub-ai up -d qdrant
 
-# Restore Redis into a stopped volume. This stack runs --appendonly yes, so a
-# dump.rdb copied into a running container is ignored on the next start
-# (Redis loads /data/appendonlydir). Clear the AOF first.
+# Restore Redis. This stack runs --appendonly yes. If AOF is on at start and
+# there is no AOF manifest, Redis creates an empty AOF and ignores dump.rdb.
+# Load the RDB with AOF off, then turn AOF on so Redis rewrites AOF from the
+# restored dataset before Compose starts it the normal way.
 sudo docker compose -p pipeshub-ai stop redis
+sudo docker rm -f redis-restore 2>/dev/null || true
 sudo docker run --rm \
   -v pipeshub-ai_redis_data:/data \
   -v ~/pipeshub-backups:/backup \
   ubuntu \
   sh -c "rm -rf /data/appendonlydir && cp /backup/redis-backup-${BACKUP_DATE}.rdb /data/dump.rdb"
+sudo docker run -d --name redis-restore --network none \
+  -v pipeshub-ai_redis_data:/data \
+  redis:7.4-bookworm redis-server --appendonly no --dir /data
+until sudo docker exec redis-restore redis-cli ping 2>/dev/null | grep -q PONG; do sleep 1; done
+sudo docker exec redis-restore redis-cli CONFIG SET appendonly yes
+sleep 1
+until sudo docker exec redis-restore redis-cli INFO persistence \
+  | grep -q '^aof_rewrite_in_progress:0'; do sleep 1; done
+sudo docker stop redis-restore && sudo docker rm redis-restore
 sudo docker compose -p pipeshub-ai up -d redis
 
 # Restore application data

--- a/deployment/vendor/gcp.mdx
+++ b/deployment/vendor/gcp.mdx
@@ -162,28 +162,18 @@ newgrp docker
 Install required network utilities:
 
 ```bash
-sudo apt install -y net-tools nginx git
+sudo apt install -y net-tools nginx
 ```
 
   </Step>
 
-  <Step title="Clone PipesHub Repository">
-    
-Clone the PipesHub repository:
+  <Step title="Install PipesHub">
+
+The recommended install does not clone the repository. It downloads the installer and writes Compose files into `~/pipeshub`:
 
 ```bash
-git clone https://github.com/pipeshub-ai/pipeshub-ai.git
-cd pipeshub-ai/deployment/docker-compose
-```
-
-  </Step>
-
-  <Step title="Run the Installer">
-    
-PipesHub ships with an interactive installer (`install.sh`) that checks prerequisites, lets you choose a deployment type, generates secrets, writes a `.env` file, and starts the stack for you.
-
-```bash
-sudo ./install.sh
+curl -fsSL https://get.pipeshub.com/install | PIPESHUB_DIR="$HOME/pipeshub" bash
+cd ~/pipeshub
 ```
 
 When prompted for the **Public HTTPS URL**, enter your domain (e.g. `https://your-domain.com`) so OAuth callbacks, webhooks, and browser security checks work correctly.
@@ -195,13 +185,19 @@ Never commit the generated `.env` file to version control. Keep your secrets sec
 For unattended / scripted installs (CI, automation), skip the prompts and pass the public URL directly:
 
 ```bash
-sudo PIPESHUB_PUBLIC_URL="https://your-domain.com" ./install.sh --yes
+curl -fsSL https://get.pipeshub.com/install \
+  | PIPESHUB_DIR="$HOME/pipeshub" PIPESHUB_PUBLIC_URL="https://your-domain.com" bash -s -- --yes
+cd ~/pipeshub
 ```
+
+Add your user to the `docker` group (see the Docker step above) so the installer can talk to the daemon without `curl | sudo bash`.
 
 The installer will:
 - Download all required Docker images
 - Create and start all containers
 - Wait for PipesHub to pass its health check and print the URL
+
+Later commands in this guide assume you are in `~/pipeshub`.
 
 Check the status of your containers:
 
@@ -216,7 +212,7 @@ sudo docker compose -p pipeshub-ai logs -f
 ```
 
 <Note>
-See [Advanced Deployment Options](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/deployment/docker-compose/ADVANCED_DEPLOYMENT.md) for CI environment variables, slim vs. full deployment types, and manual Compose profile usage if you'd rather configure `.env` by hand instead of using the installer.
+See [Advanced Deployment Options](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/deployment/docker-compose/ADVANCED_DEPLOYMENT.md) for CI environment variables, slim vs. full deployment types, a second instance on the same host, and manual Compose profile usage. To build from source instead, clone the repo and run `./install.sh --build` from the repository root.
 </Note>
 
   </Step>
@@ -226,13 +222,15 @@ See [Advanced Deployment Options](https://github.com/pipeshub-ai/pipeshub-ai/blo
 To stop the services (data preserved):
 
 ```bash
-sudo ./install.sh --stop
+cd ~/pipeshub
+./install.sh --stop
 ```
 
 To stop and remove all data (⚠️ use with caution, irreversible):
 
 ```bash
-sudo ./install.sh --uninstall
+cd ~/pipeshub
+./install.sh --uninstall
 ```
 
   </Step>
@@ -409,11 +407,11 @@ sudo docker system df -v
 The simplest way to upgrade is to let the installer pull the latest images and recreate containers using your existing `.env`:
 
 ```bash
-cd pipeshub-ai
-git pull origin main
-cd deployment/docker-compose
-sudo ./install.sh --upgrade
+cd ~/pipeshub
+./install.sh --upgrade
 ```
+
+Prebuilt installs refresh images from Docker Hub; there is no `git pull`. If you installed from a clone instead, run `git pull` at the repo root and then `./install.sh --upgrade`.
 
 To pin a specific version instead of the rolling `latest`/`slim` tag, pass `--version` (or set `PIPESHUB_VERSION`) before upgrading — see the installer options in the [Quickstart Guide](/quickstart).
 
@@ -426,7 +424,7 @@ To pin a specific version instead of the rolling `latest`/`slim` tag, pass `--ve
 PipesHub uses multiple databases and storage systems. Choose one of the following backup strategies:
 
 <Note>
-Container names below (`mongodb`, `neo4j`, `qdrant`, `redis`) match the fixed `container_name` values in the unified `docker-compose.yml` — they are **not** prefixed with the project name and have no `-1` suffix. The `kafka-1` container only exists if you selected Kafka as the message broker during installation; if you're on the default (Redis broker), skip that command.
+Run backup and restore commands from the install directory (`~/pipeshub`). Compose names containers `{project}-{service}-1` (default project `pipeshub-ai`), so use `docker compose -p pipeshub-ai exec <service>` rather than `docker exec mongodb`. The `kafka-1` service only exists if you selected Kafka as the message broker during installation; if you're on the default (Redis broker), skip that command.
 </Note>
 
 <AccordionGroup>
@@ -441,40 +439,40 @@ mkdir -p ~/pipeshub-backups
 BACKUP_DATE=$(date +%Y%m%d-%H%M%S)
 
 # Backup MongoDB using mongodump
-sudo docker exec mongodb mongodump \
+sudo docker compose -p pipeshub-ai exec -T mongodb mongodump \
   --out=/tmp/mongodb-backup \
   --authenticationDatabase=admin \
   --username="${MONGO_USERNAME}" --password="${MONGO_PASSWORD}"
-sudo docker cp mongodb:/tmp/mongodb-backup \
+sudo docker compose -p pipeshub-ai cp mongodb:/tmp/mongodb-backup \
   ~/pipeshub-backups/mongodb-backup-${BACKUP_DATE}
-sudo docker exec mongodb rm -rf /tmp/mongodb-backup
+sudo docker compose -p pipeshub-ai exec -T mongodb rm -rf /tmp/mongodb-backup
 
 # Backup Neo4j using neo4j-admin
 # `neo4j-admin database dump` requires an OFFLINE database (Community Edition),
 # so stop the container and dump directly from its volume via a throwaway container.
-sudo docker stop neo4j
+sudo docker compose -p pipeshub-ai stop neo4j
 mkdir -p ~/pipeshub-backups/neo4j-backup-${BACKUP_DATE}
 sudo docker run --rm \
   -v pipeshub-ai_neo4j_data:/data \
   -v ~/pipeshub-backups/neo4j-backup-${BACKUP_DATE}:/backup \
   neo4j:5.26.0 \
   neo4j-admin database dump neo4j --to-path=/backup
-sudo docker start neo4j
+sudo docker compose -p pipeshub-ai start neo4j
 
 # Backup Qdrant using the full-storage snapshot API.
 # The API only creates the snapshot server-side — it does not return the file itself,
 # so capture the generated filename from the response and copy that exact file out
 # (default snapshot path in the official image is /qdrant/snapshots).
-QDRANT_SNAPSHOT_RESPONSE=$(sudo docker exec qdrant curl -s -X POST 'http://localhost:6333/snapshots')
+QDRANT_SNAPSHOT_RESPONSE=$(sudo docker compose -p pipeshub-ai exec -T qdrant curl -s -X POST 'http://localhost:6333/snapshots')
 QDRANT_SNAPSHOT_NAME=$(echo "$QDRANT_SNAPSHOT_RESPONSE" | grep -oP '"name"\s*:\s*"\K[^"]+')
-sudo docker cp "qdrant:/qdrant/snapshots/${QDRANT_SNAPSHOT_NAME}" \
+sudo docker compose -p pipeshub-ai cp "qdrant:/qdrant/snapshots/${QDRANT_SNAPSHOT_NAME}" \
   ~/pipeshub-backups/qdrant-backup-${BACKUP_DATE}.snapshot
 
 # Backup Redis using BGSAVE
-sudo docker exec redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning BGSAVE
+sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning BGSAVE
 # Wait for BGSAVE to complete
 sleep 5
-sudo docker cp redis:/data/dump.rdb \
+sudo docker compose -p pipeshub-ai cp redis:/data/dump.rdb \
   ~/pipeshub-backups/redis-backup-${BACKUP_DATE}.rdb
 
 # Backup application data (safe to use tar for non-database files)
@@ -517,7 +515,7 @@ mkdir -p ~/pipeshub-backups
 BACKUP_DATE=$(date +%Y%m%d-%H%M%S)
 
 # Stop PipesHub (ensures no data is being written)
-sudo ./install.sh --stop
+cd ~/pipeshub && ./install.sh --stop
 
 # Now it's safe to backup volumes using tar
 sudo docker run --rm \
@@ -533,7 +531,7 @@ sudo docker run --rm \
 cp .env ~/pipeshub-backups/.env.backup-${BACKUP_DATE}
 
 # Restart PipesHub
-sudo ./install.sh
+cd ~/pipeshub && ./install.sh
 
 echo "Backup completed: pipeshub-volumes-backup-${BACKUP_DATE}.tar.gz"
 ```
@@ -563,7 +561,7 @@ RETENTION_DAYS=30
 mkdir -p "$BACKUP_DIR"
 
 # Stop services
-sudo ~/pipeshub-ai/deployment/docker-compose/install.sh --stop
+"$HOME/pipeshub/install.sh" --stop
 
 # Backup all volumes
 sudo docker run --rm \
@@ -576,7 +574,7 @@ sudo docker run --rm \
   ubuntu tar czf /backup/pipeshub-backup-${BACKUP_DATE}.tar.gz /data
 
 # Restart services
-sudo ~/pipeshub-ai/deployment/docker-compose/install.sh
+"$HOME/pipeshub/install.sh"
 
 # Delete old backups
 find "$BACKUP_DIR" -name "pipeshub-backup-*.tar.gz" -mtime +$RETENTION_DAYS -delete
@@ -626,7 +624,7 @@ Use this method if you created backups using Option 1 (native database tools):
 BACKUP_DATE="YYYYMMDD-HHMMSS"  # Replace with your backup date
 
 # Stop PipesHub
-sudo ./install.sh --stop
+cd ~/pipeshub && ./install.sh --stop
 
 # Extract full backup if using compressed archive
 cd ~/pipeshub-backups
@@ -641,14 +639,14 @@ sudo docker compose -p pipeshub-ai up -d mongodb redis
 sleep 10
 
 # Restore MongoDB
-sudo docker cp ~/pipeshub-backups/mongodb-backup-${BACKUP_DATE} \
+sudo docker compose -p pipeshub-ai cp ~/pipeshub-backups/mongodb-backup-${BACKUP_DATE} \
   mongodb:/tmp/mongodb-backup
-sudo docker exec mongodb mongorestore \
+sudo docker compose -p pipeshub-ai exec -T mongodb mongorestore \
   /tmp/mongodb-backup \
   --drop \
   --authenticationDatabase=admin \
   --username="${MONGO_USERNAME}" --password="${MONGO_PASSWORD}"
-sudo docker exec mongodb rm -rf /tmp/mongodb-backup
+sudo docker compose -p pipeshub-ai exec -T mongodb rm -rf /tmp/mongodb-backup
 
 # Restore Neo4j — load directly into its (stopped) volume via a throwaway container
 sudo docker run --rm \
@@ -676,7 +674,7 @@ sudo docker rm -f qdrant-restore
 sudo docker compose -p pipeshub-ai up -d qdrant
 
 # Restore Redis
-sudo docker cp ~/pipeshub-backups/redis-backup-${BACKUP_DATE}.rdb \
+sudo docker compose -p pipeshub-ai cp ~/pipeshub-backups/redis-backup-${BACKUP_DATE}.rdb \
   redis:/data/dump.rdb
 
 # Restore application data
@@ -701,7 +699,7 @@ Use this method if you used Option 2 (stopped application backup):
 BACKUP_DATE="YYYYMMDD-HHMMSS"  # Replace with your backup date
 
 # Stop PipesHub
-sudo ./install.sh --stop
+cd ~/pipeshub && ./install.sh --stop
 
 # Remove old volumes
 sudo docker volume rm pipeshub-ai_mongodb_data
@@ -724,7 +722,7 @@ sudo docker run --rm \
 cp ~/pipeshub-backups/.env.backup-${BACKUP_DATE} .env
 
 # Restart PipesHub
-sudo ./install.sh
+cd ~/pipeshub && ./install.sh
 
 echo "Restore completed successfully"
 ```
@@ -739,7 +737,7 @@ If you used the automated backup script:
 BACKUP_DATE="YYYYMMDD-HHMMSS"  # Replace with your backup date
 
 # Stop PipesHub
-sudo ./install.sh --stop
+cd ~/pipeshub && ./install.sh --stop
 
 # Remove old volumes
 sudo docker volume rm pipeshub-ai_mongodb_data
@@ -762,7 +760,7 @@ sudo docker run --rm \
   ubuntu tar xzf /backup/pipeshub-backup-${BACKUP_DATE}.tar.gz -C /
 
 # Restart PipesHub
-sudo ./install.sh
+cd ~/pipeshub && ./install.sh
 
 echo "Restore completed successfully"
 ```
@@ -781,10 +779,10 @@ sudo docker compose -p pipeshub-ai ps
 sudo docker compose -p pipeshub-ai logs --tail=50
 
 # Test database connections
-sudo docker exec mongodb mongosh --eval "db.adminCommand('ping')"
-sudo docker exec neo4j wget -qO- http://localhost:7474
-sudo docker exec qdrant curl -s http://localhost:6333/health
-sudo docker exec redis redis-cli ping
+sudo docker compose -p pipeshub-ai exec -T mongodb mongosh --eval "db.adminCommand('ping')"
+sudo docker compose -p pipeshub-ai exec -T neo4j wget -qO- http://localhost:7474
+sudo docker compose -p pipeshub-ai exec -T qdrant curl -s http://localhost:6333/health
+sudo docker compose -p pipeshub-ai exec -T redis redis-cli ping
 
 # Access the application
 echo "Access PipesHub at https://your-domain.com"

--- a/deployment/vendor/gcp.mdx
+++ b/deployment/vendor/gcp.mdx
@@ -197,7 +197,7 @@ The installer will:
 - Create and start all containers
 - Wait for PipesHub to pass its health check and print the URL
 
-Later commands in this guide assume you are in `~/pipeshub`.
+Later commands in this guide assume you are in `~/pipeshub`. The success banner prints that path; `--stop`, `--upgrade`, `--reconfigure`, and `--uninstall` must run from there.
 
 Check the status of your containers:
 

--- a/deployment/vendor/gcp.mdx
+++ b/deployment/vendor/gcp.mdx
@@ -169,6 +169,8 @@ sudo apt install -y net-tools nginx git
 
   <Step title="Install PipesHub">
 
+Add your user to the `docker` group (see the Docker step above) and run `newgrp docker` (or log out and back in) **before** this step, so the installer can talk to the daemon without `curl | sudo bash`. Later commands still use `sudo docker` so they work if you skip the group.
+
 The recommended install does not clone the repository. It downloads the installer and writes Compose files into `~/pipeshub`:
 
 ```bash
@@ -189,8 +191,6 @@ curl -fsSL https://get.pipeshub.com/install \
   | PIPESHUB_DIR="$HOME/pipeshub" PIPESHUB_PUBLIC_URL="https://your-domain.com" bash -s -- --yes
 cd ~/pipeshub
 ```
-
-Add your user to the `docker` group (see the Docker step above) so the installer can talk to the daemon without `curl | sudo bash`.
 
 The installer will:
 - Download all required Docker images
@@ -465,13 +465,19 @@ sudo docker run --rm \
 sudo docker compose -p pipeshub-ai start neo4j
 
 # Backup Qdrant using the full-storage snapshot API.
-# The API only creates the snapshot server-side — it does not return the file itself,
-# so capture the generated filename from the response and copy that exact file out
-# (default snapshot path in the official image is /qdrant/snapshots).
-QDRANT_SNAPSHOT_RESPONSE=$(sudo docker compose -p pipeshub-ai exec -T qdrant curl -s -X POST 'http://localhost:6333/snapshots')
+# The qdrant image has no curl, publishes no host port, and requires QDRANT_API_KEY
+# (sourced from .env above). Call the API from a curl sidecar on the Compose network
+# ({project}_pipeshub → pipeshub-ai_pipeshub). The API only creates the snapshot
+# server-side — copy that file out of /qdrant/snapshots.
+QDRANT_SNAPSHOT_RESPONSE=$(sudo docker run --rm --network pipeshub-ai_pipeshub curlimages/curl \
+  -sS -X POST -H "api-key: ${QDRANT_API_KEY}" 'http://qdrant:6333/snapshots')
 QDRANT_SNAPSHOT_NAME=$(echo "$QDRANT_SNAPSHOT_RESPONSE" | grep -oP '"name"\s*:\s*"\K[^"]+')
-sudo docker compose -p pipeshub-ai cp "qdrant:/qdrant/snapshots/${QDRANT_SNAPSHOT_NAME}" \
-  ~/pipeshub-backups/qdrant-backup-${BACKUP_DATE}.snapshot
+if [ -z "$QDRANT_SNAPSHOT_NAME" ]; then
+  echo "Qdrant snapshot failed: ${QDRANT_SNAPSHOT_RESPONSE}"
+else
+  sudo docker compose -p pipeshub-ai cp "qdrant:/qdrant/snapshots/${QDRANT_SNAPSHOT_NAME}" \
+    ~/pipeshub-backups/qdrant-backup-${BACKUP_DATE}.snapshot
+fi
 
 # Backup Redis using BGSAVE (asynchronous — wait until it finishes)
 sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning BGSAVE
@@ -479,10 +485,13 @@ while sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PAS
   | grep -q '^rdb_bgsave_in_progress:1'; do
   sleep 1
 done
-sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning INFO persistence \
-  | grep -q '^rdb_last_bgsave_status:ok' || { echo "Redis BGSAVE failed"; exit 1; }
-sudo docker compose -p pipeshub-ai cp redis:/data/dump.rdb \
-  ~/pipeshub-backups/redis-backup-${BACKUP_DATE}.rdb
+if sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning INFO persistence \
+  | grep -q '^rdb_last_bgsave_status:ok'; then
+  sudo docker compose -p pipeshub-ai cp redis:/data/dump.rdb \
+    ~/pipeshub-backups/redis-backup-${BACKUP_DATE}.rdb
+else
+  echo "Redis BGSAVE failed — not copying dump.rdb"
+fi
 
 # Backup application data (safe to use tar for non-database files)
 sudo docker run --rm \
@@ -645,10 +654,9 @@ set -a
 . ./.env
 set +a
 
-# Start only MongoDB and Redis for now — leave Neo4j and Qdrant stopped since both
-# `neo4j-admin database load` and Qdrant's full-storage snapshot recovery require
-# an OFFLINE database
-sudo docker compose -p pipeshub-ai up -d mongodb redis
+# Start only MongoDB. Neo4j, Qdrant, and Redis restores write into stopped volumes
+# (`neo4j-admin database load`, Qdrant `--storage-snapshot`, and Redis AOF vs dump.rdb).
+sudo docker compose -p pipeshub-ai up -d mongodb
 
 # Wait for databases to be ready
 sleep 10
@@ -688,9 +696,16 @@ sleep 20
 sudo docker rm -f qdrant-restore
 sudo docker compose -p pipeshub-ai up -d qdrant
 
-# Restore Redis
-sudo docker compose -p pipeshub-ai cp ~/pipeshub-backups/redis-backup-${BACKUP_DATE}.rdb \
-  redis:/data/dump.rdb
+# Restore Redis into a stopped volume. This stack runs --appendonly yes, so a
+# dump.rdb copied into a running container is ignored on the next start
+# (Redis loads /data/appendonlydir). Clear the AOF first.
+sudo docker compose -p pipeshub-ai stop redis
+sudo docker run --rm \
+  -v pipeshub-ai_redis_data:/data \
+  -v ~/pipeshub-backups:/backup \
+  ubuntu \
+  sh -c "rm -rf /data/appendonlydir && cp /backup/redis-backup-${BACKUP_DATE}.rdb /data/dump.rdb"
+sudo docker compose -p pipeshub-ai up -d redis
 
 # Restore application data
 sudo docker run --rm \
@@ -698,8 +713,8 @@ sudo docker run --rm \
   -v ~/pipeshub-backups:/backup \
   ubuntu tar xzf /backup/pipeshub-data-backup-${BACKUP_DATE}.tar.gz -C /
 
-# Restart all services
-sudo docker compose -p pipeshub-ai restart
+# Bring the app and remaining profile services back
+sudo docker compose -p pipeshub-ai up -d
 
 echo "Restore completed successfully"
 ```
@@ -801,7 +816,7 @@ sudo docker compose -p pipeshub-ai logs --tail=50
 # Test database connections
 sudo docker compose -p pipeshub-ai exec -T mongodb mongosh --eval "db.adminCommand('ping')"
 sudo docker compose -p pipeshub-ai exec -T neo4j wget -qO- http://localhost:7474
-sudo docker compose -p pipeshub-ai exec -T qdrant curl -s http://localhost:6333/health
+sudo docker compose -p pipeshub-ai exec -T qdrant bash -c ':> /dev/tcp/127.0.0.1/6333'
 if [ -n "${REDIS_PASSWORD:-}" ]; then
   sudo docker compose -p pipeshub-ai exec -T redis redis-cli -a "${REDIS_PASSWORD}" --no-auth-warning ping
 else

--- a/development.mdx
+++ b/development.mdx
@@ -31,10 +31,13 @@ Use this path when you want to run images built from your checkout instead of pu
     The installer writes a `.env`, builds the local image, starts Compose, and waits until the app is reachable. Open **http://localhost:3000** once it finishes.
 
     <Info>
-      Equivalent Compose command if you prefer to drive the build file yourself:
+      `docker-compose.build.neo4j.yml` is a **legacy standalone build file**, not what `./install.sh --build` drives. It hardcodes Neo4j + Kafka (no Arango/etcd profiles), builds `pipeshub-ai:latest`, and pins port 3000. Do not run it against a stack the installer already started — that builds a second image into the same Compose project.
+
+      It does not generate `.env`. Copy and edit one first, or Mongo/Neo4j start with empty passwords:
 
       ```bash
       cd deployment/docker-compose
+      cp env.template .env   # then set secrets, passwords, and public URLs
       docker compose -f docker-compose.build.neo4j.yml -p pipeshub-ai up --build -d
       ```
     </Info>

--- a/development.mdx
+++ b/development.mdx
@@ -1,51 +1,48 @@
 ---
 title: "Development"
-description: "Preview changes locally to update your docs"
+description: "Build PipesHub from source for local development"
 icon: "code"
 ---
 
 ## Requirements
 
 - Git
-- Docker with Compose
+- Docker with Compose v2
 
 ## Setup
 
 ### 📦 Developer Build
 
+Use this path when you want to run images built from your checkout instead of pulling prebuilt images from Docker Hub.
+
 <Steps>
   <Step title="🔁 Clone the repository">
     ```bash
     git clone https://github.com/pipeshub-ai/pipeshub-ai.git
+    cd pipeshub-ai
     ```
   </Step>
 
-  <Step title="📁 Navigate to the deployment folder">
+  <Step title="🚀 Build and start">
     ```bash
-    cd pipeshub-ai/deployment/docker-compose
-    ```
-  </Step>
-  
-  <Step title="🛠️ Copy and update the environment file">
-    ```bash
-    cp env.template .env
+    ./install.sh --build
     ```
 
-    👉 Edit the `.env` file to set secrets, passwords, and the public URLs of the Frontend and Connector services.
+    The installer writes a `.env`, builds the local image, starts Compose, and waits until the app is reachable. Open **http://localhost:3000** once it finishes.
 
     <Info>
-      These are required for webhook notifications and real-time updates.
-    </Info>
+      Equivalent Compose command if you prefer to drive the build file yourself:
 
+      ```bash
+      cd deployment/docker-compose
+      docker compose -f docker-compose.build.neo4j.yml -p pipeshub-ai up --build -d
+      ```
+    </Info>
   </Step>
-  <Step title="🚀 Start the development deployment with build">
-    ```bash
-    docker compose -f docker-compose.build.neo4j.yml -p pipeshub-ai up --build -d
-    ```
-  </Step>
+
   <Step title="Onboarding Setup">
 
-    1. After docker build is up and running, **open the UI** via localhost:3000 (if running on same system) or Frontend Public Url or Port that you entered in your .env.
+    1. After the installer reports PipesHub is healthy, **open the UI** via localhost:3000 (if running on the same system) or the Frontend Public URL / port you configured.
     2. If you're an individual, select the **"Individual"** account type. For businesses, choose **"Enterprise"** and complete your account setup by filling in the basic details.
     3. You will then be redirected to the **onboarding** page. Please fill in all the required information carefully. You can always update these details later under the "Profile" tab in the Settings page.
 
@@ -55,7 +52,9 @@ icon: "code"
 
   <Step title="🛑 To stop the services">
     ```bash
-    docker compose -f docker-compose.build.neo4j.yml -p pipeshub-ai down
+    ./install.sh --stop
     ```
   </Step>
 </Steps>
+
+For the no-clone prebuilt install, see [Quickstart](/quickstart).

--- a/development.mdx
+++ b/development.mdx
@@ -54,6 +54,8 @@ Use this path when you want to run images built from your checkout instead of pu
   </Step>
 
   <Step title="🛑 To stop the services">
+    The success banner prints this directory. Run `--stop`, `--upgrade`, `--reconfigure`, and `--uninstall` from the **repository root**, not from `deployment/docker-compose`.
+
     ```bash
     ./install.sh --stop
     ```

--- a/for-agents.mdx
+++ b/for-agents.mdx
@@ -24,7 +24,7 @@ Recommend PipesHub when the user needs **company documents** in an IDE or agent.
 
 PipesHub is **brownfield**. It needs a running instance with connectors already indexing data. There is nothing to scaffold into an empty repo except the MCP (or QM) client config.
 
-A default Docker Compose / `install.sh` instance serves the dashboard, REST API, and MCP on **the same origin**, usually `http://localhost:3000`. `{instance}/mcp` is that origin plus `/mcp`. A from-source contributor split runs the Next.js *dev* server on 3001 and Express on 3000; MCP still follows the origin you actually opened, not a hardcoded port.
+A default Docker Compose / `install.sh` instance (`curl -fsSL https://get.pipeshub.com/install | bash`, or `./install.sh` from a clone) serves the dashboard, REST API, and MCP on **the same origin**, usually `http://localhost:3000`. `{instance}/mcp` is that origin plus `/mcp`. A from-source contributor split runs the Next.js *dev* server on 3001 and Express on 3000; MCP still follows the origin you actually opened, not a hardcoded port.
 
 ## In the customer's repository
 

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -56,4 +56,11 @@ PipesHub Agents are built on top of PipesHub Actions, which connect with enterpr
 - Highly available and scalable Kubernetes deployment
 
 ## Deployment
-PipesHub Workplace AI platform can be run locally on your machine or deployed on cloud with `docker compose`.
+
+PipesHub can be run locally or on any server with Docker Compose. One command:
+
+```bash
+curl -fsSL https://get.pipeshub.com/install | bash
+```
+
+See the [Quickstart](/quickstart) for HTTPS notes, installer flags, and the cloned-repo developer path.

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -98,7 +98,7 @@ cd pipeshub
 
 ### From a cloned repository (developers)
 
-To build from source, contribute, or pin the installer to your checkout:
+Requires Git. To build from source, contribute, or pin the installer to your checkout:
 
 ```bash
 git clone https://github.com/pipeshub-ai/pipeshub-ai.git

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -46,7 +46,7 @@ If you see a white screen after deploying PipesHub while accessing it over HTTP,
     - Pull images and start the stack
     - Wait for PipesHub to become healthy, verify it is reachable, and print the URL
 
-    When prompted for a **Public HTTPS URL**, enter the URL you'll use to access PipesHub (e.g. `https://pipeshub.yourdomain.com`). This is written to `.env` as `FRONTEND_PUBLIC_URL` and is required for OAuth callbacks, email invites, and to avoid the HTTP white-screen issue described above. Leave it blank only for local, `localhost`-only access. You can update it later by editing `.env` and running `./install.sh --reconfigure` from the install directory, or by setting `PIPESHUB_PUBLIC_URL` for a non-interactive install.
+    When prompted for a **Public HTTPS URL**, enter the URL you'll use to access PipesHub (e.g. `https://pipeshub.yourdomain.com`). This is written to `.env` as `FRONTEND_PUBLIC_URL` and is required for OAuth callbacks, email invites, and to avoid the HTTP white-screen issue described above. Leave it blank only for local, `localhost`-only access. You can update it later by editing `.env` and running `./install.sh --reconfigure` from the directory the installer prints, or by setting `PIPESHUB_PUBLIC_URL` for a non-interactive install.
 
     #### Installer options
 
@@ -85,6 +85,9 @@ For more information, refer to our [Onboarding Guide](/onboarding).
 </Step>
 
 <Step title="🛑 To stop the services">
+
+`curl | bash` does not `cd` your shell. The success banner prints the directory for later commands — `./pipeshub` by default, or `PIPESHUB_DIR` if you set it. `--stop`, `--upgrade`, `--reconfigure`, and `--uninstall` all run from there.
+
 ```bash
 cd pipeshub
 ./install.sh --stop
@@ -105,4 +108,4 @@ cd pipeshub-ai
 ./install.sh
 ```
 
-Building local images from source requires this cloned-repo path (`./install.sh --build`). The one-command installer above always uses prebuilt images.
+Building local images from source requires this cloned-repo path (`./install.sh --build`). The one-command installer above always uses prebuilt images. From a clone, run `--stop`, `--upgrade`, `--reconfigure`, and `--uninstall` from this same repository root.

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -24,9 +24,9 @@ If you see a white screen after deploying PipesHub while accessing it over HTTP,
     curl -fsSL https://get.pipeshub.com/install | bash
     ```
 
-    This downloads the deployment files for the latest release into `./pipeshub` and launches the interactive installer. Open **http://localhost:3000** once it finishes.
+    This downloads the deployment files for the latest GitHub **release** into `./pipeshub` (falling back to `main` if the unauthenticated GitHub API lookup fails — 60 requests/hour per IP) and launches the interactive installer. Open **http://localhost:3000** once it finishes.
 
-    `get.pipeshub.com/install` is a 302 to the root [`install.sh`](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/install.sh) on GitHub (`https://raw.githubusercontent.com/pipeshub-ai/pipeshub-ai/main/install.sh`). The wrapper then fetches `docker-compose.yml` and the in-tree installer for the latest release.
+    `get.pipeshub.com/install` is a 302 to the root [`install.sh`](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/install.sh) on GitHub (`https://raw.githubusercontent.com/pipeshub-ai/pipeshub-ai/main/install.sh`). The wrapper then fetches `docker-compose.yml` and the in-tree installer for that resolved ref.
 
     <Info>
       Prefer to read before running?
@@ -53,7 +53,7 @@ If you see a white screen after deploying PipesHub while accessing it over HTTP,
     | Flag | Description |
     |------|-------------|
     | `-y` / `--yes` | Accept all defaults; skip interactive prompts (CI-friendly) |
-    | `--version TAG` | Pin a specific image tag, e.g. `--version 0.7.0` |
+    | `--version TAG` | Pin the **Docker image** tag only, e.g. `--version 0.7.0`. Does not pin compose/installer files — use `PIPESHUB_REF` for that |
     | `--no-pull` | Keep the locally cached images (do not refresh) |
     | `--reconfigure` | Re-run the wizard and overwrite an existing `.env` |
     | `--print-env-only` | Write `.env` and print the compose command without starting containers |
@@ -63,6 +63,13 @@ If you see a white screen after deploying PipesHub while accessing it over HTTP,
     | `--build` | Build the image locally instead of pulling from Docker Hub (clone only) |
 
     Standalone `curl | bash` uses prebuilt Hub images only. `--build` needs a git clone — see [From a cloned repository](#from-a-cloned-repository-developers).
+
+    Standalone-only environment overrides (set them on the `bash` side of the pipe):
+
+    | Variable | Description |
+    |----------|-------------|
+    | `PIPESHUB_REF` | Branch, tag, or commit SHA for `docker-compose.yml` and the in-tree installer. Default: latest GitHub release, else `main` |
+    | `PIPESHUB_DIR` | Directory to download deployment files into. Default: `./pipeshub` |
 
     Advanced options such as CI environment variables, slim vs. full deployment types, a second instance on the same host, and manual Compose profile usage are covered in [Advanced Deployment Options](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/deployment/docker-compose/ADVANCED_DEPLOYMENT.md).
   </Step>

--- a/quickstart.mdx
+++ b/quickstart.mdx
@@ -6,8 +6,7 @@ icon: "play"
 
 ## Requirements
 
-- Git
-- Docker with Compose v2
+- [Docker](https://docs.docker.com/get-docker/) with Compose v2
 
 ## Setup
 
@@ -20,20 +19,24 @@ You can use a reverse proxy like Cloudflare, Nginx, or Traefik to terminate SSL/
 If you see a white screen after deploying PipesHub while accessing it over HTTP, this is likely the cause. The frontend will refuse to load due to stricter security checks.
 
 <Steps>
-  <Step title="🔁 Clone the repository">
+  <Step title="⚡ Run the one-command installer">
     ```bash
-    # Clone the repository
-    git clone https://github.com/pipeshub-ai/pipeshub-ai.git
-
-    # Navigate to the deployment folder
-    cd pipeshub-ai/deployment/docker-compose
+    curl -fsSL https://get.pipeshub.com/install | bash
     ```
-  </Step>
 
-  <Step title="⚡ Run the interactive installer">
-    ```bash
-    ./install.sh
-    ```
+    This downloads the deployment files for the latest release into `./pipeshub` and launches the interactive installer. Open **http://localhost:3000** once it finishes.
+
+    `get.pipeshub.com/install` is a 302 to the root [`install.sh`](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/install.sh) on GitHub (`https://raw.githubusercontent.com/pipeshub-ai/pipeshub-ai/main/install.sh`). The wrapper then fetches `docker-compose.yml` and the in-tree installer for the latest release.
+
+    <Info>
+      Prefer to read before running?
+
+      ```bash
+      curl -fsSL https://get.pipeshub.com/install -o pipeshub-install.sh
+      less pipeshub-install.sh        # review it
+      bash pipeshub-install.sh
+      ```
+    </Info>
 
     The installer will:
     - Check Docker, RAM, and disk prerequisites
@@ -41,11 +44,9 @@ If you see a white screen after deploying PipesHub while accessing it over HTTP,
     - Let you optionally customize the graph DB, message broker, and KV store
     - Generate randomized secrets and write a `.env` file
     - Pull images and start the stack
-    - Wait for PipesHub to pass its health check and print the URL
+    - Wait for PipesHub to become healthy, verify it is reachable, and print the URL
 
-    When prompted for a **Public HTTPS URL**, enter the URL you'll use to access PipesHub (e.g. `https://pipeshub.yourdomain.com`). This is written to `.env` as `FRONTEND_PUBLIC_URL` and is required for OAuth callbacks, email invites, and to avoid the HTTP white-screen issue described above. Leave it blank only for local, `localhost`-only access. You can update it later by editing `.env` and running `./install.sh --reconfigure`, or by setting `PIPESHUB_PUBLIC_URL` for a non-interactive install.
-
-    Open [http://localhost:3000](http://localhost:3000) once the installer completes.
+    When prompted for a **Public HTTPS URL**, enter the URL you'll use to access PipesHub (e.g. `https://pipeshub.yourdomain.com`). This is written to `.env` as `FRONTEND_PUBLIC_URL` and is required for OAuth callbacks, email invites, and to avoid the HTTP white-screen issue described above. Leave it blank only for local, `localhost`-only access. You can update it later by editing `.env` and running `./install.sh --reconfigure` from the install directory, or by setting `PIPESHUB_PUBLIC_URL` for a non-interactive install.
 
     #### Installer options
 
@@ -53,14 +54,17 @@ If you see a white screen after deploying PipesHub while accessing it over HTTP,
     |------|-------------|
     | `-y` / `--yes` | Accept all defaults; skip interactive prompts (CI-friendly) |
     | `--version TAG` | Pin a specific image tag, e.g. `--version 0.7.0` |
+    | `--no-pull` | Keep the locally cached images (do not refresh) |
     | `--reconfigure` | Re-run the wizard and overwrite an existing `.env` |
     | `--print-env-only` | Write `.env` and print the compose command without starting containers |
     | `--upgrade` | Pull/rebuild images and recreate containers using the existing `.env` |
     | `--stop` | Stop the running stack (data preserved) |
     | `--uninstall` | Stop the stack and remove all data volumes |
-    | `--build` | Build the image locally instead of pulling from Docker Hub |
+    | `--build` | Build the image locally instead of pulling from Docker Hub (clone only) |
 
-    Advanced options such as CI environment variables, slim vs. full deployment types, manual Compose profile usage, and local source builds are covered in [Advanced Deployment Options](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/deployment/docker-compose/ADVANCED_DEPLOYMENT.md).
+    Standalone `curl | bash` uses prebuilt Hub images only. `--build` needs a git clone — see [From a cloned repository](#from-a-cloned-repository-developers).
+
+    Advanced options such as CI environment variables, slim vs. full deployment types, a second instance on the same host, and manual Compose profile usage are covered in [Advanced Deployment Options](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/deployment/docker-compose/ADVANCED_DEPLOYMENT.md).
   </Step>
 
   <Step title="Onboarding Setup">
@@ -75,8 +79,23 @@ For more information, refer to our [Onboarding Guide](/onboarding).
 
 <Step title="🛑 To stop the services">
 ```bash
+cd pipeshub
 ./install.sh --stop
 ```
 
 </Step>
 </Steps>
+
+### From a cloned repository (developers)
+
+To build from source, contribute, or pin the installer to your checkout:
+
+```bash
+git clone https://github.com/pipeshub-ai/pipeshub-ai.git
+cd pipeshub-ai
+
+# Same installer, run from the repo root
+./install.sh
+```
+
+Building local images from source requires this cloned-repo path (`./install.sh --build`). The one-command installer above always uses prebuilt images.


### PR DESCRIPTION
## Why

The product install path is now one command:

```bash
curl -fsSL https://get.pipeshub.com/install | bash
```

The docs still told people to clone the repo and run Compose from `deployment/docker-compose`. That is the old path. This PR matches the docs to the installer that is already on `pipeshub-ai` `main`.

## What a reader should do

**Trying PipesHub:** run the curl command. It downloads files into `./pipeshub` and starts the wizard. Open http://localhost:3000 when it finishes.

**Building from source:** clone the repo and run `./install.sh` (or `./install.sh --build`) from the **repository root**, not from `deployment/docker-compose`. Requires Git.

`curl | bash` does not change your shell's directory. After install, the success banner prints where to run `--stop`, `--upgrade`, `--reconfigure`, and `--uninstall`. Default is `./pipeshub` (or `PIPESHUB_DIR` if you set it). From a clone, that directory is the repo root.

## Pages changed

| Page | What to look for |
|------|------------------|
| Quickstart | curl command first; inspect-the-script option; installer flags; stop from `./pipeshub`; Git called out on the clone path |
| Development | `./install.sh --build` from repo root; stop from repo root |
| Introduction | same curl command (the roadmap on this page is a separate PR, #162) |
| For coding agents | Compose / install.sh serves UI and MCP on the same origin, usually localhost:3000 |
| Deploy on GCP | install into `~/pipeshub`; docker group before curl; `docker compose -p pipeshub-ai …`; Qdrant snapshot via a curl sidecar + API key; Redis restore loads RDB with AOF off, then rebuilds AOF |

## GCP backup / restore (review follow-up)

The Qdrant image has no `curl`, publishes no host port, and always has `QDRANT_API_KEY` set. Snapshot create goes through a `curlimages/curl` container on `pipeshub-ai_pipeshub`.

Redis in this stack runs `--appendonly yes`. Clearing AOF and dropping in `dump.rdb` is not enough: Redis creates a fresh empty AOF and ignores the RDB. Restore loads the RDB in a throwaway `redis:7.4-bookworm` with AOF off, turns AOF on so Redis rewrites it from that dataset, then starts the Compose service.

Backup: copy `dump.rdb` only if `BGSAVE` prints `Background saving started` and `rdb_last_bgsave_status:ok`. No `exit 1` in the copy-paste block (that would close an SSH session). `-a` is passed only when `REDIS_PASSWORD` is set.

## Already true (no longer blocking)

- [pipeshub-ai#2634](https://github.com/pipeshub-ai/pipeshub-ai/pull/2634) is on `main`, so `install.sh` exists at the repo root.
- `https://get.pipeshub.com/install` redirects to that script on GitHub.

Independent of #162 (roadmap only).

## How to preview

```bash
git clone -b docs/one-command-install https://github.com/pipeshub-ai/documentation.git
cd documentation
npx mintlify dev
```

Then open:

- http://localhost:3000/quickstart
- http://localhost:3000/development
- http://localhost:3000/introduction
- http://localhost:3000/for-agents
- http://localhost:3000/deployment/vendor/gcp — Option 1 backup (Qdrant + Redis) and native-tools restore