### PR TITLE
docs(mcp): add an Omnigent client page

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -289,13 +289,13 @@
         "pages": [
           "mcp/overview",
           "mcp/qm",
-          "mcp/omnigent",
           "mcp/cursor",
           "mcp/claude-code",
           "mcp/claude-desktop",
           "mcp/gemini-cli",
           "mcp/claude-ai",
           "mcp/librechat",
+          "mcp/omnigent",
           "mcp/local-server",
           "mcp/tools"
         ]

--- a/docs.json
+++ b/docs.json
@@ -289,6 +289,7 @@
         "pages": [
           "mcp/overview",
           "mcp/qm",
+          "mcp/omnigent",
           "mcp/cursor",
           "mcp/claude-code",
           "mcp/claude-desktop",

--- a/for-agents.mdx
+++ b/for-agents.mdx
@@ -98,6 +98,7 @@ The native shape is **remote MCP** over Streamable HTTP. No npm process is requi
 | Gemini CLI | [Connect Gemini CLI](/mcp/gemini-cli) |
 | Claude.ai | [Connect Claude.ai](/mcp/claude-ai) |
 | LibreChat | [Connect LibreChat](/mcp/librechat) |
+| Omnigent | [Connect Omnigent](/mcp/omnigent) — attach with a personal access token |
 | Local stdio bridge | [Local server](/mcp/local-server) |
 | QM | [Use with QM](/mcp/qm) — CLI in the sandbox, not MCP |
 

--- a/mcp/omnigent.mdx
+++ b/mcp/omnigent.mdx
@@ -9,7 +9,9 @@ icon: "robot"
 Each person uses **their own** PipesHub [personal access token](/developer/personal-access-tokens), so results respect their own permissions. Never share one token across a team.
 
 <Note>
-  Unlike Cursor or Claude Code, **use a personal access token here, not an OAuth app.** Omnigent's remote-MCP OAuth path expects dynamic client registration, which PipesHub does not support. A PAT is simpler and it preserves per-user permissions, which a `client_credentials` app would not.
+  **Attach with a bearer token, not an OAuth app.** Cursor and Claude Code use a registered OAuth app with a static client ID and secret. Omnigent's MCP attach takes an `Authorization` header, and its browser-OAuth path relies on dynamic client registration, which PipesHub does not support — so a PAT is the working credential here.
+
+  To be clear about identity: an OAuth app using the **authorization code** flow *does* run as the signed-in user, exactly like a PAT. It is only `client_credentials` that has no user identity — see [Unattended runs](#unattended-runs).
 </Note>
 
 ## What you need
@@ -61,7 +63,7 @@ headers:
 Then run it:
 
 ```bash
-export PIPESHUB_MCP_URL=PIPESHUB_INSTANCE_URL/mcp
+export PIPESHUB_MCP_URL=https://your-pipeshub-instance.com/mcp
 export PIPESHUB_MCP_TOKEN=phpat_…
 
 omnigent run path/to/your-agent/
@@ -105,14 +107,14 @@ That last distinction matters. "Summarize the Q3 review" needs the whole documen
 
 **A `phpat_`-prefixed token returns `401` on an older PipesHub.** Instances predating the prefix strip the token differently — upgrade PipesHub, or store the token without the `phpat_` prefix until you do.
 
-**The agent answers but never cites anything.** It probably isn't calling the tools. Check the MCP startup band in the session; a server that failed to start is named there.
+**The agent answers but never cites anything.** It probably isn't calling the tools — and on current Omnigent releases a failed MCP connection is not surfaced in the session, so the agent will answer from general knowledge in the same confident tone. Verify the endpoint with the `curl` below, and add instruction 4 above so the agent reports tool failures instead of silently continuing.
 
 **Tools appear but return nothing.** Check the token's scopes — a token only does what you granted it at creation.
 
 **Verify the endpoint independently of Omnigent:**
 
 ```bash
-curl -X POST PIPESHUB_INSTANCE_URL/mcp \
+curl -X POST https://your-pipeshub-instance.com/mcp \
   -H "Authorization: Bearer phpat_…" \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \

--- a/mcp/omnigent.mdx
+++ b/mcp/omnigent.mdx
@@ -1,0 +1,130 @@
+---
+title: "Omnigent"
+description: "Connect an Omnigent agent to the PipesHub MCP server — each person's answers stay scoped to what they can already see"
+icon: "robot"
+---
+
+[Omnigent](https://omnigent.ai) is an open-source agent framework that runs Claude Code, Codex, Cursor, and other harnesses behind one interface. It speaks MCP natively, so PipesHub attaches as a standard remote MCP server — no plugin, no fork.
+
+Each person uses **their own** PipesHub [personal access token](/developer/personal-access-tokens), so results respect their own permissions. Never share one token across a team.
+
+<Note>
+  Unlike Cursor or Claude Code, **use a personal access token here, not an OAuth app.** Omnigent's remote-MCP OAuth path expects dynamic client registration, which PipesHub does not support. A PAT is simpler and it preserves per-user permissions, which a `client_credentials` app would not.
+</Note>
+
+## What you need
+
+| You need | Why |
+| --- | --- |
+| A running PipesHub with indexed documents | That's what the agent searches |
+| A [personal access token](/developer/personal-access-tokens) | Authenticates as you, so answers stay within your access |
+| Omnigent installed (`omnigent` on your PATH) | See [Omnigent's install guide](https://omnigent.ai/quickstart/install) |
+| A model credential configured (`omnigent setup`) | Omnigent calls a model every turn |
+
+Your PipesHub instance must be reachable from wherever the agent runs. A laptop-local instance is fine for a local agent; a hosted or sandboxed runner needs a reachable URL.
+
+## Create a token
+
+1. Sign in to PipesHub
+2. Go to **Workspace-settings**
+3. Select **Personal Access Tokens** under the **Developer Settings** section
+4. Click **New token**, pick an expiry and the default scope set
+
+The token is shown once and starts with `phpat_`. The panel also gives you a ready-to-paste block containing both values used below.
+
+## Attach it to a session
+
+The fastest path — no files, no restart of anything but the session:
+
+1. Open **Agent info** on the session → **Manage MCP servers**
+2. Add a server:
+   - **URL** — `PIPESHUB_INSTANCE_URL/mcp`
+   - **Header** — `Authorization: Bearer phpat_…`
+3. Restart the session
+
+Ask it something only your organization knows the answer to. If the tools are working, the answer comes back with citations you can open.
+
+## Or put it in an agent config
+
+For an agent you want to keep or share, declare the server in a directory config. Omnigent expands `${VAR}` in both `url` and `headers` at parse time, so the file holds no endpoint and no secret and can go in version control:
+
+```yaml
+# tools/mcp/pipeshub.yaml — auto-discovered; no config.yaml entry needed
+name: pipeshub
+description: Search and chat over your organization's connected knowledge.
+transport: http
+url: ${PIPESHUB_MCP_URL}
+headers:
+  Authorization: "Bearer ${PIPESHUB_MCP_TOKEN}"
+```
+
+Then run it:
+
+```bash
+export PIPESHUB_MCP_URL=PIPESHUB_INSTANCE_URL/mcp
+export PIPESHUB_MCP_TOKEN=phpat_…
+
+omnigent run path/to/your-agent/
+```
+
+<Note>
+  `${VAR}` expansion in the `url` field requires Omnigent **v0.10.0 or later**. On older versions only `headers` expands — put the URL in literally, or upgrade.
+</Note>
+
+## Make it search instead of guess
+
+An agent with search tools will still answer from its own training data unless told not to. Put something like this in the agent's `AGENTS.md`:
+
+```markdown
+1. Search before answering. Don't answer from training data when the question
+   is about internal or company-specific information.
+2. Cite what you used, so the reader can verify it at the source.
+3. Say when you can't find something. A confident answer with no real source
+   is worse than "I couldn't find that."
+4. Notice tool failures. If a PipesHub call errors, say so rather than quietly
+   falling back to general knowledge.
+```
+
+Without point 4 in particular, a broken connection looks identical to a working one — the agent just answers from general knowledge in the same confident tone.
+
+## What the agent can do
+
+The full tool list is on [Tools Reference](/mcp/tools). The three that matter most:
+
+| Tool | Reach for it when |
+| --- | --- |
+| `pipeshub_chat` | The question spans many documents and needs synthesis |
+| `pipeshub_search` | You need to find one specific document |
+| `pipeshub_get_record_content` | The answer needs a document read *in full* — summaries, extractions, "does it mention X" |
+
+That last distinction matters. "Summarize the Q3 review" needs the whole document; a search-only tool will confidently summarize whichever fragments it matched.
+
+## Troubleshooting
+
+**Every call returns `401`.** The token is expired or revoked. Tokens can be revoked from the same page they're created on, and revocation takes effect immediately.
+
+**A `phpat_`-prefixed token returns `401` on an older PipesHub.** Instances predating the prefix strip the token differently — upgrade PipesHub, or store the token without the `phpat_` prefix until you do.
+
+**The agent answers but never cites anything.** It probably isn't calling the tools. Check the MCP startup band in the session; a server that failed to start is named there.
+
+**Tools appear but return nothing.** Check the token's scopes — a token only does what you granted it at creation.
+
+**Verify the endpoint independently of Omnigent:**
+
+```bash
+curl -X POST PIPESHUB_INSTANCE_URL/mcp \
+  -H "Authorization: Bearer phpat_…" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+A `401` here means the credential is the problem, not the agent.
+
+## Unattended runs
+
+For CI or scheduled jobs where no specific person is asking, an OAuth app with `client_credentials` is the right shape — see [OAuth 2.0 Applications](/developer/oauth2).
+
+<Warning>
+  A `client_credentials` token has **no user identity**. It is not filtered per person, so it should never back an agent that several people query. Use a personal access token for anything user-facing.
+</Warning>

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -112,6 +112,9 @@ Pick your client to connect it to the PipesHub MCP server:
   <Card title="LibreChat" icon="/logo/librechat.svg" href="/mcp/librechat">
     Remote MCP via the custom connectors UI.
   </Card>
+  <Card title="Omnigent" icon="robot" href="/mcp/omnigent">
+    Open-source agent framework — attach with a personal access token.
+  </Card>
   <Card title="Local Server (Stdio)" icon="laptop-code" href="/mcp/local-server">
     Run the MCP server locally as a stdio process.
   </Card>

--- a/mcp/overview.mdx
+++ b/mcp/overview.mdx
@@ -12,7 +12,7 @@ PipesHub exposes a **remote MCP endpoint** over **Streamable HTTP** at `/mcp`. M
   If you are a coding agent (or setting one up), start at [For coding agents](/for-agents).
 </Tip>
 
-This lets AI clients such as **Cursor**, **Claude Code**, **Gemini CLI**, **Claude.ai (Web)**, and **LibreChat** search and chat over your organization's indexed documents, look up people and groups, and download files.
+This lets AI clients such as **Cursor**, **Claude Code**, **Gemini CLI**, **Claude.ai (Web)**, **LibreChat**, and **Omnigent** search and chat over your organization's indexed documents, look up people and groups, and download files.
 
 <Note>
   Looking for the tool reference? See [Tools Reference](/mcp/tools) for descriptions, arguments, and a decision guide for each tool the MCP server exposes.
@@ -28,7 +28,7 @@ This lets AI clients such as **Cursor**, **Claude Code**, **Gemini CLI**, **Clau
 - Either an OAuth app (see [Step 1](#step-1-create-an-oauth-app) below), **or** a [Personal Access Token](/developer/personal-access-tokens) — see the note below for which one to use
 
 <Note>
-  The **client setup guides below** (Cursor, Claude Code, Gemini CLI, Claude.ai, LibreChat) connect over OAuth — you'll need an OAuth app for those.
+  Most **client setup guides below** (Cursor, Claude Code, Gemini CLI, Claude.ai, LibreChat) connect over OAuth — you'll need an OAuth app for those. [Omnigent](/mcp/omnigent) is the exception: it attaches with an `Authorization` header, so a personal access token is all you need.
 
   For your own tooling, skip OAuth entirely: create a **[Personal Access Token](/developer/personal-access-tokens)** under **Developer Settings > Personal Access Tokens** and use it as a `Bearer` token — either directly against `/mcp`, as `--bearer-auth` with the [Local Server (Stdio)](/mcp/local-server) package, or with any MCP client you configure yourself with a custom `Authorization` header.
 </Note>
@@ -85,7 +85,7 @@ Replace these placeholders in all client configurations:
 | `PIPESHUB_INSTANCE_URL` | Your PipesHub instance URL | `https://app.pipeshub.com` |
 | `YOUR_CLIENT_ID` | OAuth app client ID | `clid_abc123...` |
 | `YOUR_CLIENT_SECRET` | OAuth app client secret | `clsec_xyz789...` |
-| `YOUR_BEARER_TOKEN` | [Personal access token](/developer/personal-access-tokens) (local stdio only) | `phpat_eyJhbGci...` |
+| `YOUR_BEARER_TOKEN` | [Personal access token](/developer/personal-access-tokens) — used by the local stdio bridge and by [Omnigent](/mcp/omnigent) | `phpat_eyJhbGci...` |
 
 The remote MCP endpoint URL is: `PIPESHUB_INSTANCE_URL/mcp`
 
@@ -128,7 +128,7 @@ Pick your client to connect it to the PipesHub MCP server:
 ### Architecture
 
 ```
-AI Client (Cursor / Claude Code / Gemini CLI / Claude.ai / LibreChat)
+AI Client (Cursor / Claude Code / Gemini CLI / Claude.ai / LibreChat / Omnigent)
         │
         │  HTTP POST (JSON-RPC)
         │  Authorization: Bearer <token>


### PR DESCRIPTION
## What

Adds `mcp/omnigent.mdx` — a client setup guide for [Omnigent](https://omnigent.ai), plus the nav entry and a card on the MCP overview.

## Why

We document Cursor, Claude Code, Claude Desktop, Claude.ai, Gemini CLI, LibreChat and QM. Omnigent was missing entirely, so anyone arriving from that direction had no reason to believe PipesHub was supported — the absence reads as "not supported yet."

Omnigent speaks MCP natively, so PipesHub attaches as a standard remote MCP server. Nothing on our side had to change for this; the integration already works.

## Two things this page says that the others don't

**Use a PAT, not an OAuth app.** Cursor and Claude Code connect via a registered OAuth app. Omnigent's remote-MCP OAuth path expects **dynamic client registration**, which we don't support — our own [MCP overview](/mcp/overview) already troubleshoots that error. A personal access token is both simpler here and preserves per-user permissions.

**`client_credentials` is machine identity only.** It has no user identity, so it isn't permission-filtered per person. There's a warning beside the CI/unattended section saying it must never back an agent several people query.

## Accuracy

Every UI label and behavioural claim was checked against Omnigent's source rather than written from memory:

- **"Agent info → Manage MCP servers"** — the button label is verbatim from `AgentInfo` in the Omnigent web UI.
- **`${VAR}` in `url` needs v0.10.0+** — that expansion landed in omnigent-ai/omnigent#4398 and shipped in v0.10.0; on older versions only `headers` expands, and the page says so.
- **No DCR support** — matches the existing troubleshooting entry on our MCP overview.
- Host references use `PIPESHUB_INSTANCE_URL`, and the PAT navigation wording matches [the PAT page](/developer/personal-access-tokens).

## Checks

- `npx mintlify broken-links` → **9 broken links in 6 files**, identical to the pre-change baseline. None are new, and every internal link on the new page resolves.
- `docs.json` validated as JSON after the nav edit.

## Note on the icon

Every other client card uses `/logo/<name>.svg`. There's no Omnigent logo in `public/logo/`, so this uses the named `robot` icon — the same fallback `mcp/qm.mdx` (`terminal`) and `mcp/local-server.mdx` (`laptop-code`) already use. Happy to swap in a real mark if we add one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added setup and integration guidance for Omnigent, including authentication, session configuration, environment variables, available tools, troubleshooting, and endpoint verification.
  - Added instructions for unattended OAuth app usage and clarified token behavior.
  - Added Omnigent to the MCP Server navigation and overview page with a dedicated setup link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->