### PR TITLE
Docs: show what we already shipped on the Introduction page

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -55,8 +55,8 @@ We ship in the open. Here is what is done and what is next:
 - **Workplace AI agents** — no-code agent builder
 - **MCP** — Model Context Protocol, server and client
 - **Developer SDKs** — Python, TypeScript, and Go
-- **Code search** — GitHub, GitLab, and Bitbucket
-- **Production Kubernetes** — HA defaults
+- **Code search** — [GitHub](/connectors/github/github) and [GitLab](/connectors/gitlab/gitlab)
+- **Production Kubernetes** — [Helm chart](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/deployment/helm/pipeshub-ai/README.md) with HA presets (Neo4j Community and Redis stay single-node)
 
 **Next**
 - **Personalized search** — based on team, role, and history

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -47,13 +47,23 @@ PipesHub Agents are built on top of PipesHub Actions, which connect with enterpr
 - **Enterprise-Grade Connectors** – Scalable, reliable, and built for secure access across your organization.
 - **Modular & Scalable Architecture** – Every service is loosely coupled to scale independently and adapt to your needs.
 
-## RoadMap
-- Code Search
-- Workplace AI Agents
-- MCP
-- APIs and SDKs
-- Personalized Search
-- Highly available and scalable Kubernetes deployment
+## Roadmap
+
+We ship in the open. Here is what is done and what is next:
+
+**Shipped**
+- **Workplace AI agents** — no-code agent builder
+- **MCP** — Model Context Protocol, server and client
+- **Developer SDKs** — Python, TypeScript, and Go
+- **Code search** — GitHub, GitLab, and Bitbucket
+- **Production Kubernetes** — HA defaults
+
+**Next**
+- **Personalized search** — based on team, role, and history
+- **PageRank-augmented relevance** across the knowledge graph
+
+[Full product roadmap on Notion](https://plum-myrtle-9f7.notion.site/Pipeshub-s-Product-Roadmap-33841c164f54803a9989fd0fdbfdb1ee)
+
 
 ## Deployment
 PipesHub Workplace AI platform can be run locally on your machine or deployed on cloud with `docker compose`.


### PR DESCRIPTION
## Why

The Introduction page listed Code Search, Agents, MCP, SDKs, and Kubernetes as upcoming work. Those are already in the product. A visitor would think we had not shipped them.

## What changed

Only the **Roadmap** section on Introduction.

**Shipped:** workplace AI agents, MCP, developer SDKs, code search for GitHub and GitLab, production Kubernetes.

**Next:** personalized search, and PageRank-augmented relevance on the knowledge graph.

Code search is GitHub and GitLab only. There is no Bitbucket connector (`ConnectorFactory` registers github, github_teams, gitlab, gitlab_personal). The same README mistake is fixed in [pipeshub-ai#3088](https://github.com/pipeshub-ai/pipeshub-ai/pull/3088).

Kubernetes links to the [Helm chart README](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/deployment/helm/pipeshub-ai/README.md). The chart has HA presets for the app and most data stores; Neo4j Community and Redis stay single-node by default.

There is a link to the full Notion roadmap.

This does not change the install instructions. Those live in #154. Both PRs edit Introduction, but they edit different sections and can merge in either order.

## How to preview

```bash
git clone -b docs/intro-roadmap https://github.com/pipeshub-ai/documentation.git
cd documentation
npx mintlify dev
```

Open http://localhost:3000/introduction and check the Roadmap heading: shipped vs next, GitHub/GitLab only (no Bitbucket), Helm chart link, and that the Notion link works.

On this branch the Deployment section still says `docker compose`. That is expected until #154 merges.