### PR TITLE
docs: add pages for the 13 AI provider/capability combinations that had none

### DIFF
--- a/ai-models/embedding/litellm-proxy.mdx
+++ b/ai-models/embedding/litellm-proxy.mdx
@@ -1,0 +1,52 @@
+---
+title: LiteLLM Proxy
+description: "Configure PipesHub to generate embeddings through a self-hosted LiteLLM Proxy gateway"
+---
+
+# LiteLLM Proxy Embedding Configuration
+
+PipesHub can generate document embeddings through a LiteLLM Proxy instance, using the same gateway that serves your chat models. This keeps every model key and spending limit in one place.
+
+## Before you start
+
+You need a running LiteLLM Proxy with at least one embedding model in its `model_list`. See [LiteLLM Proxy for text generation](/ai-models/llm/litellm-proxy) for setup, and the [LiteLLM embedding documentation](https://docs.litellm.ai/docs/embedding/supported_embedding) for supported models.
+
+## Required Fields
+
+### Endpoint URL *
+
+The address where your LiteLLM Proxy is reachable.
+
+**Default:** `http://host.docker.internal:4000`
+
+Use `host.docker.internal` rather than `localhost` when the proxy runs on the Docker host, because PipesHub itself runs in a container.
+
+### API Key *
+
+The master key or a virtual key from your LiteLLM Proxy.
+
+### Model Name *
+
+The embedding model's name as defined under `model_name` in your proxy configuration — for example `text-embedding-3-small` or `azure-embeddings`.
+
+## Optional Fields
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart. If you leave it blank, the model name is used.
+
+### Dimensions
+
+The number of dimensions in the vectors this model produces. PipesHub uses it to size the vector collection.
+
+<Warning>
+Changing the embedding model or its dimensions after documents are indexed means existing vectors no longer match new ones. Re-index your content after switching.
+</Warning>
+
+### Is Multimodal
+
+Turn this on if the model can embed images as well as text. It is off by default.
+
+## Related
+
+- [LiteLLM Proxy for text generation](/ai-models/llm/litellm-proxy)

--- a/ai-models/embedding/lm-studio.mdx
+++ b/ai-models/embedding/lm-studio.mdx
@@ -1,0 +1,53 @@
+---
+title: LM Studio
+description: "Configure PipesHub to generate embeddings with a local LM Studio server"
+---
+
+# LM Studio Embedding Configuration
+
+LM Studio can serve embedding models as well as chat models, so you can index your documents entirely on your own hardware.
+
+## Before you start
+
+Download an embedding model in LM Studio — `nomic-ai/nomic-embed-text-v1.5-GGUF` is a good general-purpose choice — then load it and start the server. See [LM Studio for text generation](/ai-models/llm/lm-studio) for the full setup.
+
+## Required Fields
+
+### Endpoint URL *
+
+The address of the LM Studio server, including `/v1`.
+
+**Default:** `http://host.docker.internal:1234/v1`
+
+Use `host.docker.internal` rather than `localhost` when LM Studio runs on the Docker host.
+
+### Model Name *
+
+The embedding model's identifier, for example `nomic-ai/nomic-embed-text-v1.5-GGUF`.
+
+## Optional Fields
+
+### API Key
+
+LM Studio does not check API keys. Leave this blank unless a proxy in front of it requires one.
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart. If you leave it blank, the model name is used.
+
+### Dimensions
+
+The number of dimensions in the vectors this model produces. PipesHub uses it to size the vector collection.
+
+<Warning>
+Changing the embedding model or its dimensions after documents are indexed means existing vectors no longer match new ones. Re-index your content after switching.
+</Warning>
+
+### Is Multimodal
+
+Turn this on if the model can embed images as well as text. It is off by default.
+
+## Related
+
+- [LM Studio for text generation](/ai-models/llm/lm-studio)
+- [Sentence Transformers](/ai-models/embedding/sentence-transformer) — embeddings that run inside PipesHub with no separate server

--- a/ai-models/embedding/openrouter.mdx
+++ b/ai-models/embedding/openrouter.mdx
@@ -1,0 +1,46 @@
+---
+title: OpenRouter
+description: "Configure PipesHub to generate embeddings through OpenRouter"
+---
+
+# OpenRouter Embedding Configuration
+
+OpenRouter is a hosted gateway that routes requests to many model providers through a single API key, so you can switch models without opening a new account each time.
+
+## Before you start
+
+Create an account at [openrouter.ai](https://openrouter.ai/) and generate an API key under **Keys**.
+
+## Required Fields
+
+### API Key *
+
+Your OpenRouter API key. Keys begin with `sk-or-`.
+
+Add credit to your OpenRouter account before use; requests fail once the balance reaches zero.
+
+### Model Name *
+
+The model identifier in OpenRouter's `provider/model` form. Browse the current list on the [OpenRouter models page](https://openrouter.ai/models).
+
+## Optional Fields
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart. If you leave it blank, the model name is used.
+
+### Dimensions
+
+The number of dimensions in the vectors this model produces. PipesHub uses it to size the vector collection.
+
+<Warning>
+Changing the embedding model or its dimensions after documents are indexed means existing vectors no longer match new ones. Re-index your content after switching.
+</Warning>
+
+### Is Multimodal
+
+Turn this on if the model can embed images as well as text. It is off by default.
+
+## Related
+
+- [OpenRouter for text generation](/ai-models/llm/openrouter)

--- a/ai-models/embedding/vertex-ai.mdx
+++ b/ai-models/embedding/vertex-ai.mdx
@@ -1,0 +1,57 @@
+---
+title: Vertex AI
+description: "Configure PipesHub to generate embeddings with Google Cloud Vertex AI"
+---
+
+# Vertex AI Embedding Configuration
+
+Vertex AI serves Google's text embedding models from your own Google Cloud project, billed and governed alongside the rest of your cloud resources.
+
+## Before you start
+
+Create a service account with the **Vertex AI User** role and download a JSON key. The steps are the same as for [Vertex AI text generation](/ai-models/llm/vertex-ai).
+
+## Required Fields
+
+### GCP Project ID *
+
+The Google Cloud project that hosts Vertex AI. It must match the `project_id` inside your service account JSON.
+
+### Service Account JSON *
+
+Upload the JSON key file. PipesHub checks that it is valid JSON, contains `type`, `project_id` and `private_key`, and has `"type": "service_account"`.
+
+### Model Name *
+
+The embedding model to use, for example `text-embedding-004` or `text-multilingual-embedding-002`.
+
+Use a multilingual model if your documents are not all in English.
+
+## Optional Fields
+
+### Region
+
+The Vertex AI region, for example `us-central1`.
+
+**Default:** `us-central1`
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart. If you leave it blank, the model name is used.
+
+### Dimensions
+
+The number of dimensions in the vectors this model produces. PipesHub uses it to size the vector collection.
+
+<Warning>
+Changing the embedding model or its dimensions after documents are indexed means existing vectors no longer match new ones. Re-index your content after switching.
+</Warning>
+
+### Is Multimodal
+
+Turn this on if the model can embed images as well as text. It is off by default.
+
+## Related
+
+- [Vertex AI for text generation](/ai-models/llm/vertex-ai)
+- [Gemini for embeddings](/ai-models/embedding/gemini)

--- a/ai-models/image-generation/litellm-proxy.mdx
+++ b/ai-models/image-generation/litellm-proxy.mdx
@@ -1,0 +1,40 @@
+---
+title: LiteLLM Proxy
+description: "Configure PipesHub to generate images through a self-hosted LiteLLM Proxy gateway"
+---
+
+# LiteLLM Proxy Image Generation Configuration
+
+PipesHub can generate images through a LiteLLM Proxy instance, routing to whichever image model you have configured in the proxy.
+
+## Before you start
+
+Your LiteLLM Proxy needs at least one image model in its `model_list`. See [LiteLLM Proxy for text generation](/ai-models/llm/litellm-proxy) for setup.
+
+## Required Fields
+
+### Endpoint URL *
+
+The address of your LiteLLM Proxy.
+
+**Default:** `http://host.docker.internal:4000`
+
+Use `host.docker.internal` rather than `localhost` when the proxy runs on the Docker host.
+
+### API Key *
+
+The master key or a virtual key from your LiteLLM Proxy.
+
+### Model Name *
+
+The image model as named in your proxy configuration, for example `dall-e-3` or `gpt-image-1`.
+
+## Optional Fields
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart.
+
+## Related
+
+- [LiteLLM Proxy for text generation](/ai-models/llm/litellm-proxy)

--- a/ai-models/image-generation/openrouter.mdx
+++ b/ai-models/image-generation/openrouter.mdx
@@ -1,0 +1,32 @@
+---
+title: OpenRouter
+description: "Configure PipesHub to generate images through OpenRouter"
+---
+
+# OpenRouter Image Generation Configuration
+
+OpenRouter can serve image generation models from several providers through one API key.
+
+## Before you start
+
+Create an account at [openrouter.ai](https://openrouter.ai/) and generate an API key under **Keys**.
+
+## Required Fields
+
+### API Key *
+
+Your OpenRouter API key. Keys begin with `sk-or-`.
+
+### Model Name *
+
+The image model in OpenRouter's `provider/model` form, for example `bytedance-seed/seedream-4.5` or `black-forest-labs/flux.2-pro`. Browse the [OpenRouter models page](https://openrouter.ai/models) for what is currently offered.
+
+## Optional Fields
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart.
+
+## Related
+
+- [OpenRouter for text generation](/ai-models/llm/openrouter)

--- a/ai-models/llm/litellm-proxy.mdx
+++ b/ai-models/llm/litellm-proxy.mdx
@@ -1,0 +1,94 @@
+---
+title: LiteLLM Proxy
+description: "Configure PipesHub to reach any LLM through a self-hosted LiteLLM Proxy gateway"
+---
+
+# LiteLLM Proxy Configuration
+
+LiteLLM Proxy is a self-hosted gateway that speaks the OpenAI API and forwards requests to more than 100 upstream providers. You run it yourself, define your models in its configuration, and point PipesHub at it.
+
+Use LiteLLM Proxy when you want one place to manage keys, spending limits, and fallbacks for every model your organisation uses, instead of configuring each provider separately in PipesHub.
+
+<Info>
+LiteLLM Proxy is the only provider in PipesHub that supports all five model types: text generation, embeddings, image generation, text to speech, and speech to text. You configure each one separately, and they can point at the same proxy.
+</Info>
+
+## Before you start
+
+You need a running LiteLLM Proxy instance. Follow the [LiteLLM Proxy quick start](https://docs.litellm.ai/docs/simple_proxy) to install it and add at least one model to its `config.yaml`. Note the port it listens on; the default is `4000`.
+
+## Required Fields
+
+### Endpoint URL *
+
+The address where your LiteLLM Proxy is reachable, including the scheme and port.
+
+**Default:** `http://host.docker.internal:4000`
+
+**Which value to use:**
+
+| Where LiteLLM Proxy runs | Endpoint URL to enter |
+|---|---|
+| On the same machine as PipesHub, in Docker | `http://host.docker.internal:4000` |
+| On another server | `https://litellm.your-domain.com` |
+| In the same Docker network as PipesHub | `http://<container-name>:4000` |
+
+PipesHub runs inside a container, so `http://localhost:4000` refers to the PipesHub container itself and will not reach a proxy running on your host. Use `host.docker.internal` instead.
+
+### API Key *
+
+The master key or virtual key from your LiteLLM Proxy. This is the key you set as `master_key` in the proxy's configuration, or a virtual key you generated with it.
+
+This is not the upstream provider's key. Your OpenAI or Anthropic keys stay in the proxy's own configuration; PipesHub never sees them.
+
+### Model Name *
+
+The model name exactly as it appears under `model_name` in your LiteLLM Proxy configuration, not the upstream provider's name for it.
+
+For example, if your proxy config contains:
+
+```yaml
+model_list:
+  - model_name: my-gpt
+    litellm_params:
+      model: openai/gpt-4o
+```
+
+then enter `my-gpt` here.
+
+You can list the names your proxy exposes with:
+
+```bash
+curl http://localhost:4000/v1/models -H "Authorization: Bearer YOUR_MASTER_KEY"
+```
+
+## Optional Fields
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart. If you leave it blank, the model name is used.
+
+### Context Length
+
+The size of the model's context window, in tokens. PipesHub uses this number to decide how much retrieved content it can safely include in a prompt. Set it to the value published for your model. If you leave it blank, PipesHub uses a conservative default.
+
+### Is Multimodal
+
+Turn this on if the model accepts images as well as text. It is on by default.
+
+### Is Reasoning
+
+Turn this on if the model performs extended reasoning before answering. It is on by default.
+
+## Troubleshooting
+
+**"Connection refused" when saving.** PipesHub cannot reach the endpoint. Check that the proxy is running, and that you used `host.docker.internal` rather than `localhost` if the proxy runs on the Docker host.
+
+**"Model not found".** The model name does not match any `model_name` in the proxy configuration. List the available names with the `curl` command above.
+
+**Authentication errors.** The API Key does not match the proxy's `master_key`, or the virtual key has expired.
+
+## Related
+
+- [LiteLLM Proxy for embeddings](/ai-models/embedding/litellm-proxy)
+- [OpenAI Compatible](/ai-models/llm/openai-compatible) — for a single OpenAI-shaped endpoint rather than a multi-provider gateway

--- a/ai-models/llm/lm-studio.mdx
+++ b/ai-models/llm/lm-studio.mdx
@@ -1,0 +1,83 @@
+---
+title: LM Studio
+description: "Configure PipesHub to use local models served by LM Studio"
+---
+
+# LM Studio Configuration
+
+LM Studio is a desktop application that downloads open-source models and serves them from your own machine through an OpenAI-compatible API. Nothing leaves your computer, which makes it a good fit for private or offline work.
+
+## Before you start
+
+1. Install [LM Studio](https://lmstudio.ai/) on the machine that will run the model.
+2. Download a model from the **Discover** tab.
+3. Open the **Developer** tab (called **Local Server** in older versions), load the model, and start the server.
+4. Note the port. LM Studio uses `1234` by default, so the server address is usually `http://localhost:1234/v1`.
+
+<Warning>
+The machine running LM Studio needs enough memory to hold the model. As a rough guide, a quantised 8-billion-parameter model needs about 8 GB of free RAM, and larger models need proportionally more.
+</Warning>
+
+## Required Fields
+
+### Endpoint URL *
+
+The address of the LM Studio server, including the `/v1` path.
+
+**Default:** `http://host.docker.internal:1234/v1`
+
+**Which value to use:**
+
+| Where LM Studio runs | Endpoint URL to enter |
+|---|---|
+| On the same machine as PipesHub | `http://host.docker.internal:1234/v1` |
+| On another machine on your network | `http://192.168.1.50:1234/v1` |
+
+PipesHub runs inside a container, so `http://localhost:1234/v1` points at the PipesHub container rather than your desktop. Use `host.docker.internal` instead.
+
+If LM Studio runs on a different machine, enable **Serve on Local Network** in its server settings, otherwise it only accepts connections from its own host.
+
+### Model Name *
+
+The model identifier shown in LM Studio's server panel, for example `lmstudio-community/Meta-Llama-3.1-8B-Instruct-GGUF`.
+
+You can list the exact identifiers the server is serving with:
+
+```bash
+curl http://localhost:1234/v1/models
+```
+
+## Optional Fields
+
+### API Key
+
+LM Studio does not check API keys. Leave this blank unless you have put the server behind a proxy that requires one, in which case enter the key that proxy expects.
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart. If you leave it blank, the model name is used.
+
+### Context Length
+
+The size of the model's context window, in tokens. PipesHub uses this number to decide how much retrieved content it can safely include in a prompt. Set it to the value published for your model. If you leave it blank, PipesHub uses a conservative default.
+
+### Is Multimodal
+
+Turn this on if the model accepts images as well as text. It is on by default.
+
+### Is Reasoning
+
+Turn this on if the model performs extended reasoning before answering. It is on by default.
+
+## Troubleshooting
+
+**"Connection refused".** The LM Studio server is not running, or you used `localhost` where `host.docker.internal` is needed.
+
+**Requests time out on the first message.** LM Studio loads the model into memory on the first request, which can take a minute for a large model. Load the model in the Developer tab before using it from PipesHub.
+
+**"Model not found".** The identifier does not match. Copy it from the `curl` output above rather than typing it by hand.
+
+## Related
+
+- [LM Studio for embeddings](/ai-models/embedding/lm-studio)
+- [Ollama](/ai-models/llm/ollama) — another way to run local models

--- a/ai-models/llm/vertex-ai.mdx
+++ b/ai-models/llm/vertex-ai.mdx
@@ -1,11 +1,79 @@
 ---
 title: Vertex AI
-description: "Configure PipesHub Workplace AI to use different Vertex AI models"
+description: "Configure PipesHub Workplace AI to use Gemini models on Google Cloud Vertex AI"
 ---
 
-<div className="flex flex-col items-center justify-center text-center pt-10">
-  <h1 className=" font-bold">🚧 Coming Soon</h1>
-  <h3 className="text-xl mt-2">
-    We are working hard to bring you this content. Please check back shortly!
-  </h3>
-</div>
+# Vertex AI Configuration
+
+Vertex AI is Google Cloud's managed platform for running Gemini and other foundation models. Choose it over the direct [Gemini](/ai-models/llm/gemini) provider when you need requests billed to a Google Cloud project, kept inside a specific region, or governed by your existing IAM policies.
+
+Vertex AI authenticates with a service account JSON key that you upload in PipesHub. It does not use an API key, and it does not read credentials from environment variables.
+
+## Before you start
+
+1. In the [Google Cloud Console](https://console.cloud.google.com/), select or create a project.
+2. Enable the **Vertex AI API** for that project.
+3. Go to **IAM & Admin → Service Accounts** and create a service account.
+4. Grant it the **Vertex AI User** role, or a role that includes it.
+5. Open the service account, go to the **Keys** tab, and create a new JSON key. The file downloads once — keep it safe.
+
+## Required Fields
+
+### GCP Project ID *
+
+The Google Cloud project that hosts Vertex AI. This must match the `project_id` field inside your service account JSON file.
+
+### Service Account JSON *
+
+Upload the JSON key file you created above. PipesHub validates the file before saving and will reject it if:
+
+- the file is not valid JSON,
+- it is missing `type`, `project_id`, or `private_key`, or
+- its `type` field is not `service_account` — which usually means an OAuth client secret was uploaded by mistake.
+
+The key is stored encrypted and is used only to authenticate requests to Vertex AI.
+
+### Model Name *
+
+The Vertex AI model to call, for example `gemini-2.5-flash` or `gemini-2.5-pro`.
+
+Check Google's [Vertex AI model reference](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models) for the current list, and confirm the model is available in the region you chose.
+
+## Optional Fields
+
+### Region
+
+The Vertex AI region requests are sent to, for example `us-central1` or `europe-west4`.
+
+**Default:** `us-central1`
+
+Pick a region close to your users for lower latency, or one that satisfies your data residency requirements. Not every model is offered in every region.
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart. If you leave it blank, the model name is used.
+
+### Context Length
+
+The size of the model's context window, in tokens. PipesHub uses this number to decide how much retrieved content it can safely include in a prompt. Set it to the value published for your model. If you leave it blank, PipesHub uses a conservative default.
+
+### Is Multimodal
+
+Turn this on if the model accepts images as well as text. It is on by default.
+
+### Is Reasoning
+
+Turn this on if the model performs extended reasoning before answering. It is on by default.
+
+## Troubleshooting
+
+**"Permission denied".** The service account is missing the Vertex AI User role, or the Vertex AI API is not enabled on the project.
+
+**"Model not found" in a specific region.** The model is not offered there. Try `us-central1`, which carries the widest selection.
+
+**The upload is rejected.** You uploaded an OAuth client secret rather than a service account key. Open the file and confirm `"type": "service_account"`.
+
+## Related
+
+- [Vertex AI for embeddings](/ai-models/embedding/vertex-ai)
+- [Gemini](/ai-models/llm/gemini) — the same models through Google AI Studio, with an API key instead of a service account

--- a/ai-models/stt/litellm-proxy.mdx
+++ b/ai-models/stt/litellm-proxy.mdx
@@ -1,0 +1,41 @@
+---
+title: LiteLLM Proxy
+description: "Configure PipesHub to transcribe audio through a self-hosted LiteLLM Proxy gateway"
+---
+
+# LiteLLM Proxy Speech to Text Configuration
+
+PipesHub can transcribe spoken audio into text through a LiteLLM Proxy instance, so voice input and audio files are handled by the same gateway as your other models.
+
+## Before you start
+
+Your LiteLLM Proxy needs at least one transcription model in its `model_list`. See [LiteLLM Proxy for text generation](/ai-models/llm/litellm-proxy) for setup.
+
+## Required Fields
+
+### Endpoint URL *
+
+The address of your LiteLLM Proxy.
+
+**Default:** `http://host.docker.internal:4000`
+
+Use `host.docker.internal` rather than `localhost` when the proxy runs on the Docker host.
+
+### API Key *
+
+The master key or a virtual key from your LiteLLM Proxy.
+
+### Model Name *
+
+The transcription model as named in your proxy configuration, for example `whisper-1`.
+
+## Optional Fields
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart.
+
+## Related
+
+- [LiteLLM Proxy for text generation](/ai-models/llm/litellm-proxy)
+- [Whisper](/ai-models/stt/whisper) — transcription that runs locally with no external service

--- a/ai-models/stt/openrouter.mdx
+++ b/ai-models/stt/openrouter.mdx
@@ -1,0 +1,32 @@
+---
+title: OpenRouter
+description: "Configure PipesHub to transcribe audio through OpenRouter"
+---
+
+# OpenRouter Speech to Text Configuration
+
+OpenRouter can serve transcription models from several providers through one API key.
+
+## Before you start
+
+Create an account at [openrouter.ai](https://openrouter.ai/) and generate an API key under **Keys**.
+
+## Required Fields
+
+### API Key *
+
+Your OpenRouter API key. Keys begin with `sk-or-`.
+
+### Model Name *
+
+The transcription model in OpenRouter's `provider/model` form, for example `openai/whisper-1`.
+
+## Optional Fields
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart.
+
+## Related
+
+- [OpenRouter for text generation](/ai-models/llm/openrouter)

--- a/ai-models/tts/litellm-proxy.mdx
+++ b/ai-models/tts/litellm-proxy.mdx
@@ -1,0 +1,48 @@
+---
+title: LiteLLM Proxy
+description: "Configure PipesHub to generate speech through a self-hosted LiteLLM Proxy gateway"
+---
+
+# LiteLLM Proxy Text to Speech Configuration
+
+PipesHub can turn AI responses into spoken audio through a LiteLLM Proxy instance, using the same gateway that serves your chat and embedding models.
+
+## Before you start
+
+Your LiteLLM Proxy needs at least one text-to-speech model in its `model_list`. See [LiteLLM Proxy for text generation](/ai-models/llm/litellm-proxy) for setup.
+
+## Required Fields
+
+### Endpoint URL *
+
+The address of your LiteLLM Proxy.
+
+**Default:** `http://host.docker.internal:4000`
+
+Use `host.docker.internal` rather than `localhost` when the proxy runs on the Docker host.
+
+### API Key *
+
+The master key or a virtual key from your LiteLLM Proxy.
+
+### Model Name *
+
+The speech model as named in your proxy configuration, for example `tts-1` or `tts-1-hd`.
+
+## Optional Fields
+
+### Voice
+
+The voice used for the generated speech. The values available depend on the upstream model you route to.
+
+### Audio Format
+
+The container format of the returned audio, such as `mp3`, `opus`, `aac`, `flac`, `wav`, or `pcm`. Choose `mp3` unless you have a reason not to; it is the most widely playable.
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart.
+
+## Related
+
+- [LiteLLM Proxy for text generation](/ai-models/llm/litellm-proxy)

--- a/ai-models/tts/openrouter.mdx
+++ b/ai-models/tts/openrouter.mdx
@@ -1,0 +1,40 @@
+---
+title: OpenRouter
+description: "Configure PipesHub to generate speech through OpenRouter"
+---
+
+# OpenRouter Text to Speech Configuration
+
+OpenRouter can serve text-to-speech models from several providers through one API key.
+
+## Before you start
+
+Create an account at [openrouter.ai](https://openrouter.ai/) and generate an API key under **Keys**.
+
+## Required Fields
+
+### API Key *
+
+Your OpenRouter API key. Keys begin with `sk-or-`.
+
+### Model Name *
+
+The speech model in OpenRouter's `provider/model` form, for example `openai/gpt-4o-mini-tts-2025-12-15`. Browse the [OpenRouter models page](https://openrouter.ai/models) for what is currently offered.
+
+## Optional Fields
+
+### Voice
+
+The voice used for the generated speech. The values available depend on the upstream model you route to.
+
+### Audio Format
+
+The container format of the returned audio, such as `mp3`, `opus`, `aac`, `flac`, `wav`, or `pcm`. Choose `mp3` unless you have a reason not to; it is the most widely playable.
+
+### Model Friendly Name
+
+A label shown in the PipesHub interface so you can tell several configurations apart.
+
+## Related
+
+- [OpenRouter for text generation](/ai-models/llm/openrouter)

--- a/docs.json
+++ b/docs.json
@@ -100,7 +100,9 @@
               "ai-models/llm/vertex-ai",
               "ai-models/llm/deepseek",
               "ai-models/llm/openrouter",
-              "ai-models/llm/vllm"
+              "ai-models/llm/vllm",
+              "ai-models/llm/litellm-proxy",
+              "ai-models/llm/lm-studio"
             ]
           },
           {
@@ -120,21 +122,29 @@
               "ai-models/embedding/huggingface",
               "ai-models/embedding/jina",
               "ai-models/embedding/voyage",
-              "ai-models/embedding/bedrock"
+              "ai-models/embedding/bedrock",
+              "ai-models/embedding/vertex-ai",
+              "ai-models/embedding/openrouter",
+              "ai-models/embedding/litellm-proxy",
+              "ai-models/embedding/lm-studio"
             ]
           },
           {
             "group": "Image Generation Providers",
             "pages": [
               "ai-models/image-generation/openai",
-              "ai-models/image-generation/gemini"
+              "ai-models/image-generation/gemini",
+              "ai-models/image-generation/openrouter",
+              "ai-models/image-generation/litellm-proxy"
             ]
           },
           {
             "group": "TTS Providers",
             "pages": [
               "ai-models/tts/openai",
-              "ai-models/tts/gemini"
+              "ai-models/tts/gemini",
+              "ai-models/tts/openrouter",
+              "ai-models/tts/litellm-proxy"
             ]
           },
           {
@@ -143,7 +153,9 @@
               "ai-models/stt/openai",
               "ai-models/stt/gemini",
               "ai-models/stt/whisper",
-              "ai-models/stt/wispr-flow"
+              "ai-models/stt/wispr-flow",
+              "ai-models/stt/openrouter",
+              "ai-models/stt/litellm-proxy"
             ]
           }
         ]


### PR DESCRIPTION
## Why

Thirteen provider and capability combinations are selectable in **Settings → AI Models** but had no documentation. LiteLLM Proxy is the starkest case: `litellm_proxy.py` declares all five capabilities — text generation, embedding, image generation, TTS and STT — the widest set of any provider, and it had no page at all.

`ai-models/llm/vertex-ai.mdx` was a 360-byte "Coming Soon" stub for a provider that is fully supported and marked `.popular()` in the registry.

## Where the content comes from

Every field name, requirement, default and validation rule is read out of `backend/python/app/config/ai_models/providers/`, not written from memory:

| Page content | Source |
|---|---|
| LiteLLM Proxy fields, all 5 capabilities | `litellm_proxy.py` |
| LM Studio fields, `API_KEY_OPTIONAL` | `lm_studio.py` |
| Vertex AI project / region / JSON upload | `vertex_ai.py` |
| OpenRouter model placeholders | `openrouter.py` |
| Friendly name, context length, dimensions | `common_fields.py` |

Two details worth calling out because they are easy to get wrong by guessing:

**Endpoint defaults use `host.docker.internal`, not `localhost`.** That is what `default_value` says in both `_LITELLM_ENDPOINT` and `_LM_STUDIO_ENDPOINT`, and it is correct — PipesHub runs in a container, so `localhost` resolves to the container itself. Each page explains this, since it is the most common setup failure for a locally hosted model server.

**LM Studio's API key is optional.** It uses `API_KEY_OPTIONAL` because LM Studio does not validate keys. The page says so rather than telling people to invent one.

**Vertex AI's upload validation is documented exactly as enforced** — valid JSON, `type`/`project_id`/`private_key` present, and `type == "service_account"` — so a reader who uploads an OAuth client secret by mistake can recognise the error.

## Writing

Aimed at being followed literally by a person or an agent: prerequisites before the step that needs them, one idea per step, concrete values rather than gestures at them, and a short troubleshooting section keyed to the errors each provider actually produces. Endpoint choices are given as tables (where the server runs → what to type) so the answer can be extracted without inference.

## Not included

The telemetry page, by request — it is tracked separately.

## Note on links

The repo-wide link check still reports 9 broken links on `main`. All of them are pre-existing and fixed in #163; none are in these new pages. These two PRs are independent and can merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HpNmn9X69EiiBEDGYTmLWZ
