### PR TITLE
docs: the legacy compose file does not hardcode Kafka

### DIFF
--- a/development.mdx
+++ b/development.mdx
@@ -31,7 +31,7 @@ Use this path when you want to run images built from your checkout instead of pu
     The installer writes a `.env`, builds the local image, starts Compose, and waits until the app is reachable. Open **http://localhost:3000** once it finishes.
 
     <Info>
-      `docker-compose.build.neo4j.yml` is a **legacy standalone build file**, not what `./install.sh --build` drives. It hardcodes Neo4j + Kafka (no Arango/etcd profiles), builds `pipeshub-ai:latest`, and pins port 3000. Do not run it against a stack the installer already started — that builds a second image into the same Compose project.
+      `docker-compose.build.neo4j.yml` is a **legacy standalone build file**, not what `./install.sh --build` drives. It hardcodes `DATA_STORE=neo4j` and has no ArangoDB or etcd profiles, builds `pipeshub-ai:latest`, and pins port 3000. (Kafka is available in it as an opt-in profile; the broker still defaults to Redis.) Do not run it against a stack the installer already started — that builds a second image into the same Compose project.
 
       It does not generate `.env`. Copy and edit one first, or Mongo/Neo4j start with empty passwords:
 


### PR DESCRIPTION
## The problem

`development.mdx` describes `docker-compose.build.neo4j.yml` as hardcoding "Neo4j + Kafka". Only the Neo4j half is true.

```
docker-compose.build.neo4j.yml:76    DATA_STORE=neo4j                          hardcoded
docker-compose.build.neo4j.yml:85    MESSAGE_BROKER=${MESSAGE_BROKER:-redis}   defaults to Redis
docker-compose.build.neo4j.yml:289   profiles: ["kafka"]                       opt-in
docker-compose.build.neo4j.yml:305   profiles: ["kafka"]                       opt-in
```

Kafka is an opt-in profile in that file, not a fixture. A reader following the page expects a Kafka broker and gets Redis Streams instead — the opposite of what the page promises.

## The change

The sentence now names what is genuinely fixed in the file, and mentions the Kafka profile for what it is.

## The rest of the sentence is accurate and unchanged

- **"no Arango/etcd profiles"** — correct, neither string appears anywhere in the file
- **"builds `pipeshub-ai:latest`"** — correct, line 3
- **"pins port 3000"** — correct, line 18