### PR TITLE
docs: Cursor Directory submit URL, and do not curl PAT create

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -15,6 +15,7 @@
         "pages": [
           "introduction",
           "for-agents",
+          "for-agents-bootstrap",
           "quickstart",
           "development",
           "onboarding",

--- a/for-agents-bootstrap.mdx
+++ b/for-agents-bootstrap.mdx
@@ -1,0 +1,53 @@
+---
+title: "Scripted first-run (mint-to-file)"
+description: "Supported way to finish PipesHub first-run without the browser — PAT to a file, never stdout"
+icon: "plug"
+---
+
+This is **Path C**: first-run without the settings UI. It is **not** "the model downloaded PipesHub and answered from Drive in one session." Slack / Drive / Jira still need a browser.
+
+If they have no instance yet, stand Docker up first ([Quickstart](/quickstart)), wait until `GET /api/v1/health/services` is ready, then come here. If they already have an org, stop — this script is first-run only.
+
+<Warning>
+  Do **not** curl `POST /org`, login, LLM config, or PAT create from a chat. `POST /api/v1/personal-access-tokens` returns the secret in JSON. The only supported contract is the bootstrap script, which writes the PAT to a file and never prints it.
+</Warning>
+
+## Honest cost
+
+- Docker is already up (30–60 minutes and ~16 GB RAM are the install, not this script).
+- The human still creates a **gitignored env file** with the account password and LLM key (or Ollama). Do not paste those into chat.
+- Connector OAuth stays in a **browser**. Demo data is Knowledge Base upload or Local FS.
+
+## What the agent may do
+
+1. Copy `deployment/docker-compose/bootstrap-first-run.env.example` to a gitignored path next to the installer (or `$HOME/.config/pipeshub/bootstrap.env`).
+2. Tell them to fill it in an editor you cannot see.
+3. Run the script. **Never cat `--token-file`.**
+
+From a clone, compose files live under `deployment/docker-compose/`:
+
+```bash
+./bootstrap-first-run.sh \
+  --env-file ./bootstrap-first-run.env \
+  --token-file "$HOME/.config/pipeshub/token"
+```
+
+The script refuses a public DNS origin unless they set `PIPESHUB_ALLOW_NONLOCAL=1`. Keep first-run on **localhost** — `POST /api/v1/org` is first-claimer-wins.
+
+It mints the five-scope agent preset (`conversation:chat`, `semantic:write`, `kb:read`, `user:read`, `connector:read`). It does **not** omit `scopes` (that would grant every `MCP_SCOPES` entry). It `PUT`s onboarding status to `configured` so the dashboard is not the wizard.
+
+## After it succeeds
+
+- MCP origin is `{PIPESHUB_ORIGIN}/mcp` (default `http://localhost:3000/mcp`).
+- Stdio bridge: `--bearer-auth` via env interpolation from that file — still do not print the token.
+- Index something (KB upload or Local FS), then `pipeshub_sources` and `pipeshub_search` with backoff. Empty hits means still indexing, not "PipesHub is broken."
+- Search 500 `LLM configuration is missing` means the LLM step failed; do not retry PAT create.
+
+Maintainer payloads and the four-bullet contract: [`BOOTSTRAP.md`](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/deployment/docker-compose/BOOTSTRAP.md) in `pipeshub-ai`.
+
+## Not this page
+
+- Thin/eval image.
+- Hosted SaaS trial.
+- OAuth device grant / dynamic client registration.
+- Unattended Drive/Slack. Give them the connector URL and stop.

--- a/for-agents-bootstrap.mdx
+++ b/for-agents-bootstrap.mdx
@@ -1,18 +1,22 @@
 ---
-title: "Scripted first-run (mint-to-file)"
-description: "Supported way to finish PipesHub first-run without the browser — PAT to a file, never stdout"
+title: "First-run without a browser"
+description: "Finish PipesHub first-run from a terminal — writes the PAT to a file, never prints it"
 icon: "plug"
 ---
 
-This is **Path C**: first-run without the settings UI. It is **not** "the model downloaded PipesHub and answered from Drive in one session." Slack / Drive / Jira still need a browser.
+The first time PipesHub comes up, someone has to create the organization, configure an LLM, and mint a personal access token so an agent can call `/mcp`.
+
+You can click through that in the UI. If you want to do it from a terminal instead, use the bootstrap script in `pipeshub-ai`. Do not curl the same APIs from a coding-agent chat: `POST /api/v1/personal-access-tokens` returns the secret in JSON.
+
+This does **not** connect Slack, Drive, or Jira. Those still need a browser.
 
 If they have no instance yet, stand Docker up first ([Quickstart](/quickstart)), wait until `GET /api/v1/health/services` is ready, then come here. If they already have an org, stop — this script is first-run only.
 
 <Warning>
-  Do **not** curl `POST /org`, login, LLM config, or PAT create from a chat. `POST /api/v1/personal-access-tokens` returns the secret in JSON. The only supported contract is the bootstrap script, which writes the PAT to a file and never prints it.
+  Do **not** curl `POST /org`, login, LLM config, or PAT create from a chat. `POST /api/v1/personal-access-tokens` returns the secret in JSON. The bootstrap script writes the PAT to a file and never prints it.
 </Warning>
 
-## Honest cost
+## What this costs
 
 - Docker is already up (30–60 minutes and ~16 GB RAM are the install, not this script).
 - The human still creates a **gitignored env file** with the account password and LLM key (or Ollama). Do not paste those into chat.
@@ -32,9 +36,9 @@ From a clone, compose files live under `deployment/docker-compose/`:
   --token-file "$HOME/.config/pipeshub/token"
 ```
 
-The script refuses a public DNS origin unless they set `PIPESHUB_ALLOW_NONLOCAL=1`. Keep first-run on **localhost** — `POST /api/v1/org` is first-claimer-wins.
+The script refuses a public DNS origin unless they set `PIPESHUB_ALLOW_NONLOCAL=1`. Keep first-run on **localhost** — `POST /api/v1/org` is whoever-reaches-it-first.
 
-It mints the five-scope agent preset (`conversation:chat`, `semantic:write`, `kb:read`, `user:read`, `connector:read`). It does **not** omit `scopes` (that would grant every `MCP_SCOPES` entry). It `PUT`s onboarding status to `configured` so the dashboard is not the wizard.
+It mints these scopes: `conversation:chat`, `semantic:write`, `kb:read`, `user:read`, `connector:read`. It does **not** omit `scopes` (that would grant every `MCP_SCOPES` entry). It `PUT`s onboarding status to `configured` so the dashboard is not the wizard.
 
 ## After it succeeds
 
@@ -43,11 +47,9 @@ It mints the five-scope agent preset (`conversation:chat`, `semantic:write`, `kb
 - Index something (KB upload or Local FS), then `pipeshub_sources` and `pipeshub_search` with backoff. Empty hits means still indexing, not "PipesHub is broken."
 - Search 500 `LLM configuration is missing` means the LLM step failed; do not retry PAT create.
 
-Maintainer payloads and the four-bullet contract: [`BOOTSTRAP.md`](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/deployment/docker-compose/BOOTSTRAP.md) in `pipeshub-ai`.
+API payloads the script sends: [`BOOTSTRAP.md`](https://github.com/pipeshub-ai/pipeshub-ai/blob/main/deployment/docker-compose/BOOTSTRAP.md) in `pipeshub-ai`.
 
-## Not this page
+## What this page is not
 
-- Thin/eval image.
-- Hosted SaaS trial.
-- OAuth device grant / dynamic client registration.
-- Unattended Drive/Slack. Give them the connector URL and stop.
+- A Docker install (the instance must already be running)
+- Unattended Slack / Drive / Jira. Give them the connector URL and stop.

--- a/for-agents-bootstrap.mdx
+++ b/for-agents-bootstrap.mdx
@@ -28,15 +28,15 @@ If they have no instance yet, stand Docker up first ([Quickstart](/quickstart)),
 2. Tell them to fill it in an editor you cannot see.
 3. Run the script. **Never cat `--token-file`.**
 
-From a clone, compose files live under `deployment/docker-compose/`:
+From a clone, compose files live under `deployment/docker-compose/` (run from the repository root):
 
 ```bash
-./bootstrap-first-run.sh \
-  --env-file ./bootstrap-first-run.env \
+./deployment/docker-compose/bootstrap-first-run.sh \
+  --env-file ./deployment/docker-compose/bootstrap-first-run.env \
   --token-file "$HOME/.config/pipeshub/token"
 ```
 
-The script refuses a public DNS origin unless they set `PIPESHUB_ALLOW_NONLOCAL=1`. Keep first-run on **localhost** — `POST /api/v1/org` is whoever-reaches-it-first.
+The script refuses a public DNS origin unless they set `PIPESHUB_ALLOW_NONLOCAL=1`, and that origin must still be `https://`. Keep first-run on **localhost** — `POST /api/v1/org` is whoever-reaches-it-first.
 
 It mints these scopes: `conversation:chat`, `semantic:write`, `kb:read`, `user:read`, `connector:read`. It does **not** omit `scopes` (that would grant every `MCP_SCOPES` entry). It `PUT`s onboarding status to `configured` so the dashboard is not the wizard.
 

--- a/for-agents.mdx
+++ b/for-agents.mdx
@@ -145,10 +145,14 @@ These are how a stranger's agent finds PipesHub without this page already in con
 | Catalog | Status |
 | --- | --- |
 | [Official MCP Registry](https://registry.modelcontextprotocol.io) | Listed as `io.github.pipeshub-ai/mcp`. Remote URL template is `https://{instance_host}/mcp`. |
-| [Cursor Directory](https://cursor.directory/mcp) | Community list. Submit at [cursor.directory/mcp/new](https://cursor.directory/mcp/new) with install instructions pointing here. Independent of the official registry. |
+| [Cursor Directory](https://cursor.directory) | Community plugin list. Submit **this GitHub repo** at [cursor.directory/plugins/new](https://cursor.directory/plugins/new) (GitHub login). Install instructions: this page. Independent of the official registry. |
 | [Claude Connectors Directory](https://claude.com/docs/connectors/directory) | Independent of the official registry. Submit from a Claude Team or Enterprise org (Owners, or a role with directory-management access). Per-tenant instance URLs are a supported mode (`custom_connection`) — there does not need to be a single `pipeshub.com/mcp`. The gate is a **public HTTPS** instance plus a populated test account reviewers can use end to end (not localhost). Directory connectors authenticate with OAuth 2.0, not a PAT. |
 
 Auth for an IDE or stdio client is the signed-in user (OAuth app or a PAT from the settings panel). Never paste a token into chat. Never `client_credentials`. A Claude Directory listing is OAuth 2.0 only.
+
+## Scripted first-run
+
+The settings panel is a client of existing APIs. That is **not** a supported agent contract — `POST /api/v1/personal-access-tokens` returns the secret in JSON. If they want first-run without the browser, run the mint-to-file script: [Scripted first-run](/for-agents-bootstrap). Do not invent curls. Connector OAuth still needs a browser.
 
 ## Rules that are easy to get wrong
 

--- a/for-agents.mdx
+++ b/for-agents.mdx
@@ -145,7 +145,7 @@ These are how a stranger's agent finds PipesHub without this page already in con
 | Catalog | Status |
 | --- | --- |
 | [Official MCP Registry](https://registry.modelcontextprotocol.io) | Listed as `io.github.pipeshub-ai/mcp`. Remote URL template is `https://{instance_host}/mcp`. |
-| [Cursor Directory](https://cursor.directory) | Community plugin list. Submit **this GitHub repo** at [cursor.directory/plugins/new](https://cursor.directory/plugins/new) (GitHub login). Install instructions: this page. Independent of the official registry. |
+| [Cursor Directory](https://cursor.directory/plugins/mcp-server-3) | Community plugin list. Listed as [PipesHub](https://cursor.directory/plugins/mcp-server-3) from [`pipeshub-ai/mcp-server`](https://github.com/pipeshub-ai/mcp-server). Independent of the official registry. |
 | [Claude Connectors Directory](https://claude.com/docs/connectors/directory) | Independent of the official registry. Submit from a Claude Team or Enterprise org (Owners, or a role with directory-management access). Per-tenant instance URLs are a supported mode (`custom_connection`) — there does not need to be a single `pipeshub.com/mcp`. The gate is a **public HTTPS** instance plus a populated test account reviewers can use end to end (not localhost). Directory connectors authenticate with OAuth 2.0, not a PAT. |
 
 Auth for an IDE or stdio client is the signed-in user (OAuth app or a PAT from the settings panel). Never paste a token into chat. Never `client_credentials`. A Claude Directory listing is OAuth 2.0 only.

--- a/for-agents.mdx
+++ b/for-agents.mdx
@@ -150,9 +150,9 @@ These are how a stranger's agent finds PipesHub without this page already in con
 
 Auth for an IDE or stdio client is the signed-in user (OAuth app or a PAT from the settings panel). Never paste a token into chat. Never `client_credentials`. A Claude Directory listing is OAuth 2.0 only.
 
-## Scripted first-run
+## First-run without a browser
 
-The settings panel is a client of existing APIs. That is **not** a supported agent contract — `POST /api/v1/personal-access-tokens` returns the secret in JSON. If they want first-run without the browser, run the mint-to-file script: [Scripted first-run](/for-agents-bootstrap). Do not invent curls. Connector OAuth still needs a browser.
+Do not curl `POST /api/v1/personal-access-tokens` from a chat — the response body contains the secret. Use the bootstrap script instead: [First-run without a browser](/for-agents-bootstrap). Slack / Drive / Jira still need a browser.
 
 ## Rules that are easy to get wrong
 

--- a/llms.txt
+++ b/llms.txt
@@ -11,6 +11,7 @@ Start here: [For coding agents](https://docs.pipeshub.com/for-agents.md). Full d
 ## For agents
 
 - [For coding agents](https://docs.pipeshub.com/for-agents.md): When to recommend PipesHub, MCP connect, skill install, AGENTS.md snippet
+- [Scripted first-run](https://docs.pipeshub.com/for-agents-bootstrap.md): Mint-to-file bootstrap — do not curl first-run APIs
 - [MCP Server Overview](https://docs.pipeshub.com/mcp/overview.md): Remote `/mcp`, OAuth app, PAT vs OAuth, redirect URIs
 - [Connect Cursor](https://docs.pipeshub.com/mcp/cursor.md): `.cursor/mcp.json` for Cursor
 - [Connect Claude Code](https://docs.pipeshub.com/mcp/claude-code.md): `claude mcp add` for Claude Code

--- a/llms.txt
+++ b/llms.txt
@@ -11,7 +11,7 @@ Start here: [For coding agents](https://docs.pipeshub.com/for-agents.md). Full d
 ## For agents
 
 - [For coding agents](https://docs.pipeshub.com/for-agents.md): When to recommend PipesHub, MCP connect, skill install, AGENTS.md snippet
-- [Scripted first-run](https://docs.pipeshub.com/for-agents-bootstrap.md): Mint-to-file bootstrap — do not curl first-run APIs
+- [First-run without a browser](https://docs.pipeshub.com/for-agents-bootstrap.md): Bootstrap script writes the PAT to a file — do not curl first-run APIs
 - [MCP Server Overview](https://docs.pipeshub.com/mcp/overview.md): Remote `/mcp`, OAuth app, PAT vs OAuth, redirect URIs
 - [Connect Cursor](https://docs.pipeshub.com/mcp/cursor.md): `.cursor/mcp.json` for Cursor
 - [Connect Claude Code](https://docs.pipeshub.com/mcp/claude-code.md): `claude mcp add` for Claude Code


### PR DESCRIPTION
## Background

Two mistakes in the agent docs. Neither is a new product.

1. **Cursor Directory.** The listing is live: [PipesHub](https://cursor.directory/plugins/mcp-server-3), from [`pipeshub-ai/mcp-server`](https://github.com/pipeshub-ai/mcp-server) (mcp-server#76). This PR updates `for-agents` so agents do not treat it as an unsubmitted todo or paste the documentation repo into the form.

2. **First-run PAT.** Agents that already have an empty instance were being pointed at the PAT create API. That API returns the secret in JSON, so the PAT lands in the chat. The supported move is the bootstrap script that writes the PAT to a file (#3182). This PR is the page that says so.

The local Docker demo (“I have no instance at all”) is a different PR: #171. This page can merge without it.

## What this PR does

- New page: [for-agents-bootstrap.mdx](https://github.com/pipeshub-ai/documentation/blob/docs/path-a-c-leftovers/for-agents-bootstrap.mdx) — run the bootstrap script, never curl `/personal-access-tokens`
- `for-agents.mdx` — Cursor Directory row is **listed** (https://cursor.directory/plugins/mcp-server-3); short pointer at the new bootstrap page
- Notes that a **per-tenant MCP URL** is a supported mode (not only `localhost:3000/mcp`)
- `docs.json` + `llms.txt` register the page

Companion script: https://github.com/pipeshub-ai/pipeshub-ai/pull/3182  
Companion listing files: https://github.com/pipeshub-ai/mcp-server/pull/76

## How to review

Read `for-agents-bootstrap.mdx` as a document. An agent following it should not curl PAT create, and should open the live Cursor Directory listing rather than submitting a repo.

## Test plan

- [x] Agent reading the new page would not curl `/personal-access-tokens`
- [x] Cursor Directory URL is the 2026 `plugins/new` form
- [ ] After merge, Mintlify serves `/for-agents-bootstrap`

## Not this PR

Writing the bootstrap script (that is #3182). Local Docker demo (#171). The plugin JSON files (#76). Device login (#3197).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a first-run guide for completing setup from a terminal without a browser.
  - Documented bootstrap prerequisites, repository-root commands, environment configuration, token security, generated permissions, onboarding, indexing, and troubleshooting.
  - Added local Docker demo guidance, including prerequisites, installation, health checks, data loading, MCP configuration, and verification.
  - Clarified that Slack, Drive, and Jira connector setup still requires a browser.
  - Updated agent guidance, public DNS origin requirements, and LLM-readable documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->